### PR TITLE
Update to Cubism 4 SDK for Java R1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [4-r.1] - 2023-05-25
+
+### Added
+
+* Add some functions for checking consistency of MOC3 files.
+  * Add the function of checking consistency in `CubismMoc.create()`.
+  * Add the function of checking consistency before loading a model. (`CubismUserModel.loadModel()`)
+* Add some functions to change Multiply and Screen colors on a per part basis.
+
+### Changed
+
+* Change access modifiers for methods in `CubismExpressionMotion`. And also chenge it to non-final class, allowing it to be extended by inheritance.
+* Change to get opacity according to the current time of the motion.
+
+### Fixed
+* Refactor codes of cacheing vertex information in renderer.
+  * This change does not affect the behavior of this SDK.
+* Fix a crash when specifying the number of mask buffers as an integer less than or equal to 0 in the second argument of `setupRenderer` function in `CubismUserModel`.
+* Fix the redundant process regarding the renderer to make the code more concise.
+* Optimize a drawing process of clipping masks.
+  * `CubismClippingManagerAndroid` class has a flag to indicate whether mask textures have been cleared or not, and the texture clearing process is only called if they have not been cleared.
+
 ## [4-r.1-beta.4] - 2023-03-16
 
 ### Fixed
@@ -73,7 +95,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 * New released!
 
-
+[4-r.1]: https://github.com/Live2D/CubismJavaFramework/compare/4-r.1-beta.4...4-r.1
 [4-r.1-beta.4]: https://github.com/Live2D/CubismJavaFramework/compare/4-r.1-beta.3...4-r.1-beta.4
 [4-r.1-beta.3]: https://github.com/Live2D/CubismJavaFramework/compare/4-r.1-beta.2...4-r.1-beta.3
 [4-r.1-beta.2]: https://github.com/Live2D/CubismJavaFramework/compare/4-r.1-beta.1...4-r.1-beta.2

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismMoc.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismMoc.java
@@ -18,15 +18,38 @@ import java.text.ParseException;
  */
 public class CubismMoc {
     /**
-     * Read Moc file from buffer, and create Moc data.
+     * バッファからMocファイルを読み取り、Mocデータを作成する。
+     * NOTE: デフォルトではMOC3の整合性をチェックしない。
      *
-     * @param mocBytes A buffer of Moc file
+     * @param mocBytes MOC3ファイルのバイト配列バッファ
+     * @return MOC3ファイルのインスタンス
      */
     public static CubismMoc create(byte[] mocBytes) {
+        return create(mocBytes, false);
+    }
+
+    /**
+     * バッファからMocファイルを読み取り、Mocデータを作成する。
+     *
+     * @param mocBytes            MOC3ファイルのバイト配列バッファ
+     * @param shouldCheckMocConsistency MOC3の整合性をチェックするか。trueならチェックする。
+     * @return MOC3ファイルのインスタンス
+     */
+    public static CubismMoc create(byte[] mocBytes, boolean shouldCheckMocConsistency) {
         com.live2d.sdk.cubism.core.CubismMoc moc;
 
         if (mocBytes == null) {
             return null;
+        }
+
+        if (shouldCheckMocConsistency) {
+            // .moc3の整合性を確認する。
+            boolean consistency = hasMocConsistency(mocBytes);
+
+            if (!consistency) {
+                CubismDebug.cubismLogError("Inconsistent MOC3.");
+                return null;
+            }
         }
 
         try {

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismUserModel.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismUserModel.java
@@ -7,20 +7,25 @@
 
 package com.live2d.sdk.cubism.framework.model;
 
+import static com.live2d.sdk.cubism.framework.CubismFramework.VERTEX_OFFSET;
+import static com.live2d.sdk.cubism.framework.CubismFramework.VERTEX_STEP;
+import static com.live2d.sdk.cubism.framework.utils.CubismDebug.cubismLogError;
+import static com.live2d.sdk.cubism.framework.utils.CubismDebug.cubismLogInfo;
+
 import com.live2d.sdk.cubism.framework.effect.CubismBreath;
 import com.live2d.sdk.cubism.framework.effect.CubismEyeBlink;
 import com.live2d.sdk.cubism.framework.effect.CubismPose;
 import com.live2d.sdk.cubism.framework.id.CubismId;
 import com.live2d.sdk.cubism.framework.math.CubismModelMatrix;
 import com.live2d.sdk.cubism.framework.math.CubismTargetPoint;
-import com.live2d.sdk.cubism.framework.motion.*;
+import com.live2d.sdk.cubism.framework.motion.CubismExpressionMotion;
+import com.live2d.sdk.cubism.framework.motion.CubismMotion;
+import com.live2d.sdk.cubism.framework.motion.CubismMotionManager;
+import com.live2d.sdk.cubism.framework.motion.CubismMotionQueueManager;
+import com.live2d.sdk.cubism.framework.motion.ICubismMotionEventFunction;
+import com.live2d.sdk.cubism.framework.motion.IFinishedMotionCallback;
 import com.live2d.sdk.cubism.framework.physics.CubismPhysics;
 import com.live2d.sdk.cubism.framework.rendering.CubismRenderer;
-
-import static com.live2d.sdk.cubism.framework.CubismFramework.VERTEX_OFFSET;
-import static com.live2d.sdk.cubism.framework.CubismFramework.VERTEX_STEP;
-import static com.live2d.sdk.cubism.framework.utils.CubismDebug.cubismLogError;
-import static com.live2d.sdk.cubism.framework.utils.CubismDebug.cubismLogInfo;
 
 /**
  * This is the base class of the model that the user actually utilizes. The user defined model class inherits this class.
@@ -256,12 +261,22 @@ public abstract class CubismUserModel {
     }
 
     /**
-     * Read a model data
+     * モデルデータを読み込む。
+     * NOTE: デフォルトではMOC3の整合性をチェックしない。
      *
-     * @param buffer a buffer where the moc3 file is loaded
+     * @param buffer MOC3ファイルが読み込まれているバイト配列バッファ
      */
     protected void loadModel(final byte[] buffer) {
-        final CubismMoc moc = CubismMoc.create(buffer);
+        loadModel(buffer, false);
+    }
+
+    /**
+     * モデルデータを読み込む。
+     *
+     * @param buffer MOC3ファイルが読み込まれているバイト配列バッファ
+     */
+    protected void loadModel(final byte[] buffer, boolean shouldCheckMocConsistency) {
+        final CubismMoc moc = CubismMoc.create(buffer, shouldCheckMocConsistency);
 
         if (moc == null) {
             cubismLogError("Failed to create CubismMoc instance.");
@@ -448,6 +463,10 @@ public abstract class CubismUserModel {
      * An acceleration in Z-axis direction
      */
     protected float accelerationZ;
+    /**
+     * MOC3の整合性を検証するか。検証するならtrue。
+     */
+    protected boolean mocConsistency;
     /**
      * Whether it is debug mode
      */

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/ACubismMotion.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/ACubismMotion.java
@@ -215,7 +215,7 @@ public abstract class ACubismMotion {
      *
      * @return return true if the key exists
      */
-    public boolean isExistOpacity() {
+    public boolean isExistModelOpacity() {
         return false;
     }
 
@@ -225,7 +225,7 @@ public abstract class ACubismMotion {
      *
      * @return success: index of the transparency curve
      */
-    public int getOpacityIndex() {
+    public int getModelOpacityIndex() {
         return -1;
     }
 
@@ -234,18 +234,8 @@ public abstract class ACubismMotion {
      *
      * @return success: atransparency curve
      */
-    public CubismId getOpacityId(int index) {
+    public CubismId getModelOpacityId(int index) {
         return null;
-    }
-
-    /**
-     * Return the transparency value for the specified time.
-     *
-     * @param motionTimeSeconds current playback duration[s]
-     * @return transparency value the value of Opacity at the relevant time of the motion
-     */
-    public float getOpacityValue(float motionTimeSeconds) {
-        return 1.0f;
     }
 
     /**
@@ -262,6 +252,16 @@ public abstract class ACubismMotion {
         float weight,
         CubismMotionQueueEntry motionQueueEntry
     );
+
+    /**
+     * 指定時間の透明度の値を返す。
+     * NOTE: 更新後の値を取るには`updateParameters()` の後に呼び出す。
+     *
+     * @return success : モーションの当該時間におけるOpacityの値
+     */
+    protected float getModelOpacityValue() {
+        return 1.0f;
+    }
 
     /**
      * Time for fade-in [s]

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismMotionManager.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismMotionManager.java
@@ -34,28 +34,16 @@ public class CubismMotionManager extends CubismMotionQueueManager {
     }
 
     /**
-     * Update the motion without opacity information.
+     * Update the motion and reflect the parameter values to the model.
      *
      * @param model target model
      * @param deltaTimeSeconds delta time[s]
      * @return If it is updated, return true.
      */
     public boolean updateMotion(CubismModel model, float deltaTimeSeconds) {
-        return updateMotion(model, deltaTimeSeconds, null);
-    }
-
-    /**
-     * Update the motion and reflect the parameter values to the model.
-     *
-     * @param model target model
-     * @param deltaTimeSeconds delta time[s]
-     * @param opacity opcity(Nullable)
-     * @return If it is updated, return true.
-     */
-    public boolean updateMotion(CubismModel model, float deltaTimeSeconds, float[] opacity) {
         userTimeSeconds += deltaTimeSeconds;
 
-        final boolean isUpdated = doUpdateMotion(model, userTimeSeconds, opacity);
+        final boolean isUpdated = doUpdateMotion(model, userTimeSeconds);
 
         if (isFinished()) {
             currentPriority = 0;   // 再生中モーションの優先度を解除

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismMotionQueueManager.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismMotionQueueManager.java
@@ -141,10 +141,9 @@ public class CubismMotionQueueManager {
      *
      * @param model target model
      * @param userTimeSeconds total delta time[s]
-     * @param opacity opacity(Nullable)
      * @return If reflecting the parameter value to the model(the motion is changed.) is successed, return true.
      */
-    protected boolean doUpdateMotion(CubismModel model, float userTimeSeconds, float[] opacity) {
+    protected boolean doUpdateMotion(CubismModel model, float userTimeSeconds) {
         boolean isUpdated = false;
 
         // ---- Do processing ----
@@ -164,11 +163,6 @@ public class CubismMotionQueueManager {
 
             motion.updateParameters(model, motionQueueEntry, userTimeSeconds);
             isUpdated = true;
-
-            // Reflect the opacity value if it exists.
-            if (opacity != null) {
-                opacity[0] = motion.getOpacityValue(userTimeSeconds - motionQueueEntry.getStartTime());
-            }
 
             // Inspect user-triggered events.
             final List<String> firedList = motion.getFiredEvent(

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismDrawableInfoCachesHolder.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismDrawableInfoCachesHolder.java
@@ -1,0 +1,123 @@
+package com.live2d.sdk.cubism.framework.rendering.android;
+
+import com.live2d.sdk.cubism.framework.model.CubismModel;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
+import java.nio.ShortBuffer;
+
+/**
+ * Drawableの情報を格納するバッファをキャッシュし保持するクラス。
+ */
+class CubismDrawableInfoCachesHolder {
+    public CubismDrawableInfoCachesHolder(CubismModel model) {
+        final int drawableCount = model.getDrawableCount();
+        final int[] renderOrder = model.getDrawableRenderOrders();
+        final int[] sortedDrawableIndexList = new int[drawableCount];
+
+        // Sort the index by drawing order
+        for (int i = 0; i < drawableCount; i++) {
+            final int order = renderOrder[i];
+            sortedDrawableIndexList[order] = i;
+        }
+        vertexArrayCaches = new FloatBuffer[drawableCount];
+        uvArrayCaches = new FloatBuffer[drawableCount];
+        indexArrayCaches = new ShortBuffer[drawableCount];
+
+        for (int i = 0; i < drawableCount; i++) {
+            final int drawableIndex = sortedDrawableIndexList[i];
+
+            // Vertex Array
+            {
+                float[] vertexArray = model.getDrawableVertices(drawableIndex);
+
+                ByteBuffer bb = ByteBuffer.allocateDirect(vertexArray.length * 4);
+                bb.order(ByteOrder.nativeOrder());
+                FloatBuffer buffer = bb.asFloatBuffer();
+                vertexArrayCaches[drawableIndex] = buffer;
+            }
+
+            // UV Array
+            {
+                float[] uvArray = model.getDrawableVertexUvs(drawableIndex);
+
+                ByteBuffer bb = ByteBuffer.allocateDirect(uvArray.length * 4);
+                bb.order(ByteOrder.nativeOrder());
+                FloatBuffer buffer = bb.asFloatBuffer();
+                uvArrayCaches[drawableIndex] = buffer;
+            }
+
+            // Index Array
+            {
+                short[] indexArray = model.getDrawableVertexIndices(drawableIndex);
+
+                ByteBuffer bb = ByteBuffer.allocateDirect(indexArray.length * 4);
+                bb.order(ByteOrder.nativeOrder());
+                ShortBuffer buffer = bb.asShortBuffer();
+                indexArrayCaches[drawableIndex] = buffer;
+            }
+        }
+    }
+
+    /**
+     * Drawableの頂点をキャッシュされたバッファに入れて返す。
+     *
+     * @param drawableIndex 取得したいDrawableのインデックス
+     * @param drawableVertices Drawableの頂点が格納された配列
+     * @return 頂点バッファ
+     */
+    public FloatBuffer setUpVertexArray(int drawableIndex, float[] drawableVertices) {
+        FloatBuffer vertexArray = vertexArrayCaches[drawableIndex];
+        vertexArray.clear();
+        vertexArray.put(drawableVertices);
+        vertexArray.position(0);
+
+        return vertexArray;
+    }
+
+    /**
+     * DrawableのUV情報をキャッシュされたバッファに入れて返す。
+     *
+     * @param drawableIndex 取得したいDrawableのインデックス
+     * @param drawableVertexUvs DrawableのUV情報が入った配列
+     * @return UV情報バッファ
+     */
+    public FloatBuffer setUpUvArray(int drawableIndex, float[] drawableVertexUvs) {
+        FloatBuffer uvArray = uvArrayCaches[drawableIndex];
+        uvArray.clear();
+        uvArray.put(drawableVertexUvs);
+        uvArray.position(0);
+
+        return uvArray;
+    }
+
+    /**
+     * Drawableの頂点に対するポリゴンの対応番号をキャッシュされたバッファに入れて返す。
+     *
+     * @param drawableIndex 取得したいDrawableのインデックス
+     * @param drawableIndices Drawableの頂点に対するポリゴンの対応番号の配列
+     * @return 頂点に対するポリゴンの対応番号のバッファ
+     */
+    public ShortBuffer setUpIndexArray(int drawableIndex, short[] drawableIndices) {
+        ShortBuffer indexArray = indexArrayCaches[drawableIndex];
+        indexArray.clear();
+        indexArray.put(drawableIndices);
+        indexArray.position(0);
+
+        return indexArray;
+    }
+
+    /**
+     * Drawableの頂点のキャッシュ配列
+     */
+    private final FloatBuffer[] vertexArrayCaches;
+    /**
+     * DrawableのUV情報のキャッシュ配列
+     */
+    private final FloatBuffer[] uvArrayCaches;
+    /**
+     * Drawableの頂点に対するポリゴンの対応番号のキャッシュ配列
+     */
+    private final ShortBuffer[] indexArrayCaches;
+}

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismOffscreenSurfaceAndroid.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismOffscreenSurfaceAndroid.java
@@ -203,6 +203,15 @@ public class CubismOffscreenSurfaceAndroid {
         }
     }
 
+    /**
+     * レンダーテクスチャのアドレス（intの配列型）を取得する。
+     *
+     * @return レンダーテクスチャのアドレス
+     */
+    public int[] getRenderTexture() {
+        return renderTexture;
+    }
+
 
     /**
      * Get color buffer.

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismShaderAndroid.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismShaderAndroid.java
@@ -256,10 +256,8 @@ class CubismShaderAndroid {
 
             if (isMasked) {
                 glActiveTexture(GL_TEXTURE1);
-                int tex =
-                    renderer.getClippingContextBufferForDraw()
-                            .getClippingManager()
-                            .getColorBuffer()[renderer.getClippingContextBufferForDraw().bufferIndex];
+                // Framebufferに描かれたテクスチャ
+                int tex = renderer.getMaskBuffer(renderer.getClippingContextBufferForDraw().bufferIndex).getColorBuffer()[0];
                 glBindTexture(GL_TEXTURE_2D, tex);
                 glUniform1i(shaderSet.samplerTexture1Location, 1);
 


### PR DESCRIPTION
### Added

* Add some functions for checking consistency of MOC3 files.
  * Add the function of checking consistency in `CubismMoc.create()`.
  * Add the function of checking consistency before loading a model. (`CubismUserModel.loadModel()`)
* Add some functions to change Multiply and Screen colors on a per part basis.

### Changed

* Change access modifiers for methods in `CubismExpressionMotion`. And also chenge it to non-final class, allowing it to be extended by inheritance.
* Change to get opacity according to the current time of the motion.

### Fixed
* Refactor codes of cacheing vertex information in renderer.
  * This change does not affect the behavior of this SDK.
* Fix a crash when specifying the number of mask buffers as an integer less than or equal to 0 in the second argument of `setupRenderer` function in `CubismUserModel`.
* Fix the redundant process regarding the renderer to make the code more concise.
* Optimize a drawing process of clipping masks.
  * `CubismClippingManagerAndroid` class has a flag to indicate whether mask textures have been cleared or not, and the texture clearing process is only called if they have not been cleared.