### PR TITLE
Update to Cubism 5 SDK for Java R1 beta3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [5-r.1-beta.3] - 2024-01-18
+
+### Added
+
+* Add exception catching and error logging handling when an exception is thrown while loading a JSON file.
+
+### Changed
+
+* Change the compile and target SDK version of Android OS to 14.0 (API 34).
+  * Upgrade the version of Android Gradle Plugin from 8.0.2 to 8.1.1.
+  * Upgrade the version of Gradle from 8.1.1 to 8.2.
+  * Change the minimum version of Android Studio to Hedgehog(2023.1.1).
+* Change the visibility of the `CubismPhysicsInternal` and `CubismPhysicsJson` classes to `public`.
+
+### Fixed
+
+* Fix an issue where models with a specific number of masks could not be drawn correctly.
+* Replace deprecated notation in `build.gradle`.
+
+
 ## [5-r.1-beta.2] - 2023-09-28
 
 ### Added
@@ -134,6 +154,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 * New released!
 
+[5-r.1-beta.3]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.1-beta.2...5-r.1-beta.3
 [5-r.1-beta.2]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.1-beta.1...5-r.1-beta.2
 [5-r.1-beta.1]: https://github.com/Live2D/CubismJavaFramework/compare/4-r.1...5-r.1-beta.1
 [4-r.1]: https://github.com/Live2D/CubismJavaFramework/compare/4-r.1-beta.4...4-r.1

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.1.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "com.live2d.sdk.cubism.framework"
-    compileSdkVersion PROP_COMPILE_SDK_VERSION.toInteger()
+    compileSdk PROP_COMPILE_SDK_VERSION.toInteger()
 
     defaultConfig {
         minSdkVersion PROP_MIN_SDK_VERSION

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismUserModel.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismUserModel.java
@@ -327,7 +327,12 @@ public abstract class CubismUserModel {
         byte[] buffer,
         IFinishedMotionCallback onFinishedMotionHandler
     ) {
-        return CubismMotion.create(buffer, onFinishedMotionHandler);
+        try {
+            return CubismMotion.create(buffer, onFinishedMotionHandler);
+        } catch (Exception e) {
+            cubismLogError("Failed to loadMotion(). %s", e.getMessage());
+            return null;
+        }
     }
 
     /**
@@ -337,7 +342,7 @@ public abstract class CubismUserModel {
      * @return motion class
      */
     protected CubismMotion loadMotion(byte[] buffer) {
-        return CubismMotion.create(buffer, null);
+        return loadMotion(buffer, null);
     }
 
     /**
@@ -347,7 +352,12 @@ public abstract class CubismUserModel {
      * @return motion class
      */
     protected CubismExpressionMotion loadExpression(final byte[] buffer) {
-        return CubismExpressionMotion.create(buffer);
+        try {
+            return CubismExpressionMotion.create(buffer);
+        } catch (Exception e) {
+            cubismLogError("Failed to loadExpressionMotion(). %s", e.getMessage());
+            return null;
+        }
     }
 
     /**
@@ -356,7 +366,11 @@ public abstract class CubismUserModel {
      * @param buffer a buffer where pose3.json is loaded.
      */
     protected void loadPose(final byte[] buffer) {
-        pose = CubismPose.create(buffer);
+        try {
+            pose = CubismPose.create(buffer);
+        } catch (Exception e) {
+            cubismLogError("Failed to loadPose(). %s", e.getMessage());
+        }
     }
 
     /**
@@ -365,7 +379,11 @@ public abstract class CubismUserModel {
      * @param buffer a buffer where physics3.json is loaded.
      */
     protected void loadPhysics(final byte[] buffer) {
-        physics = CubismPhysics.create(buffer);
+        try {
+            physics = CubismPhysics.create(buffer);
+        } catch (Exception e) {
+            cubismLogError("Failed to loadPhysics(). %s", e.getMessage());
+        }
     }
 
     /**
@@ -374,7 +392,11 @@ public abstract class CubismUserModel {
      * @param buffer a buffer where userdata3.json is loaded.
      */
     protected void loadUserData(final byte[] buffer) {
-        modelUserData = CubismModelUserData.create(buffer);
+        try {
+            modelUserData = CubismModelUserData.create(buffer);
+        } catch (Exception e) {
+            cubismLogError("Failed to loadUserData(). %s", e.getMessage());
+        }
     }
 
     /**

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/physics/CubismPhysicsInternal.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/physics/CubismPhysicsInternal.java
@@ -16,7 +16,7 @@ import java.util.List;
 /**
  * Internal data of CubismPhysics.
  */
-class CubismPhysicsInternal {
+public class CubismPhysicsInternal {
     /**
      * Types of physics operations to be applied.
      */

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/physics/CubismPhysicsJson.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/physics/CubismPhysicsJson.java
@@ -15,7 +15,7 @@ import com.live2d.sdk.cubism.framework.utils.jsonparser.CubismJson;
 /**
  * A manager of physics3.json.
  */
-class CubismPhysicsJson {
+public class CubismPhysicsJson {
     /**
      * Constructor
      *

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/ACubismClippingContext.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/ACubismClippingContext.java
@@ -102,7 +102,7 @@ public abstract class ACubismClippingContext {
     /**
      * RGBAのいずれのチャンネルにこのクリップを配置するか（0:R, 1:G, 2:B, 3:A）
      */
-    public int layoutChannelNo;
+    public int layoutChannelIndex;
 
     /**
      * マスク用チャンネルのどの領域にマスクを入れるか(View座標-1..1, UVは0..1に直す)

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/ICubismClippingManager.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/ICubismClippingManager.java
@@ -96,8 +96,8 @@ public interface ICubismClippingManager {
     /**
      * カラーチャンネル（RGBA）のフラグを取得する。
      *
-     * @param channelNo カラーチャンネル（RGBA）の番号（0:R, 1:G, 2:B, 3:A）
+     * @param channelIndex カラーチャンネル（RGBA）の番号（0:R, 1:G, 2:B, 3:A）
      * @return カラーチャンネルのフラグ
      */
-    CubismRenderer.CubismTextureColor getChannelFlagAsColor(int channelNo);
+    CubismRenderer.CubismTextureColor getChannelFlagAsColor(int channelIndex);
 }

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismRendererAndroid.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismRendererAndroid.java
@@ -123,11 +123,11 @@ public class CubismRendererAndroid extends CubismRenderer {
     /**
      * Bind processing of OpenGL textures.
      *
-     * @param modelTextureNo number of the model texture to set
-     * @param glTextureNo    number of the OpenGL texture to bind
+     * @param modelTextureIndex number of the model texture to set
+     * @param glTextureIndex    number of the OpenGL texture to bind
      */
-    public void bindTexture(int modelTextureNo, int glTextureNo) {
-        textures.put(modelTextureNo, glTextureNo);
+    public void bindTexture(int modelTextureIndex, int glTextureIndex) {
+        textures.put(modelTextureIndex, glTextureIndex);
         areTexturesChanged = true;
     }
 

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismShaderAndroid.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismShaderAndroid.java
@@ -167,11 +167,11 @@ class CubismShaderAndroid {
             );
 
             // Set used color channel.
-            final int channelNumber = renderer.getClippingContextBufferForDraw().layoutChannelNo;
+            final int channelIndex = renderer.getClippingContextBufferForDraw().layoutChannelIndex;
             CubismRenderer.CubismTextureColor colorChannel = renderer
                 .getClippingContextBufferForDraw()
                 .getClippingManager()
-                .getChannelFlagAsColor(channelNumber);
+                .getChannelFlagAsColor(channelIndex);
             glUniform4f(
                 shaderSet.uniformChannelFlagLocation,
                 colorChannel.r,
@@ -290,11 +290,11 @@ class CubismShaderAndroid {
         );
 
         // channels
-        final int channelNumber = renderer.getClippingContextBufferForMask().layoutChannelNo;
+        final int channelIndex = renderer.getClippingContextBufferForMask().layoutChannelIndex;
         CubismRenderer.CubismTextureColor colorChannel = renderer
             .getClippingContextBufferForMask()
             .getClippingManager()
-            .getChannelFlagAsColor(channelNumber);
+            .getChannelFlagAsColor(channelIndex);
 
         glUniform4f(
             shaderSet.uniformChannelFlagLocation,

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,8 +18,8 @@ android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
 # Android SDK version that will be used as the compiled project
-PROP_COMPILE_SDK_VERSION=33
+PROP_COMPILE_SDK_VERSION=34
 # Android SDK version that will be used as the earliest version of android this application can run on
 PROP_MIN_SDK_VERSION=21
 # Android SDK version that will be used as the latest version of android this application has been tested on
-PROP_TARGET_SDK_VERSION=33
+PROP_TARGET_SDK_VERSION=34

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jul 11 18:25:17 JST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Added

* Add exception catching and error logging handling when an exception is thrown while loading a JSON file.

### Changed

* Change the compile and target SDK version of Android OS to 14.0 (API 34).
  * Upgrade the version of Android Gradle Plugin from 8.0.2 to 8.1.1.
  * Upgrade the version of Gradle from 8.1.1 to 8.2.
  * Change the minimum version of Android Studio to Hedgehog(2023.1.1).
* Change the visibility of the `CubismPhysicsInternal` and `CubismPhysicsJson` classes to `public`.

### Fixed

* Fix an issue where models with a specific number of masks could not be drawn correctly.
* Replace deprecated notation in `build.gradle`.