### PR TITLE
Update to Cubism 5 SDK for Java R2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+
+## [5-r.2] - 2024-11-07
+
+### Added
+
+* Add function to get `CombinedParameters` listed in `cdi3.json`.
+* Add the functionality to call a function when motion playback starts.
+
+### Changed
+
+* Change the access level of `CubismMotionJson` class to public.
+* Change the threshold for enabling anisotropic filtering.
+
+### Fixed
+
+* Fix a bug in which a method to acquire events fired during motion playback returned incorrect values when called multiple times.
+* Fix a potential problem with division by 0 when a pose fade time is set to 0 seconds.
+* Fix a bug that thrown an exception when playing CubismExpresionMotion with CubismMotionQueueManager.startMotion().
+
+
 ## [5-r.1] - 2024-03-26
 
 ### Added
@@ -180,6 +200,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 * New released!
 
+[5-r.2]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.1...5-r.2
 [5-r.1]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.1-beta.3...5-r.1
 [5-r.1-beta.3]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.1-beta.2...5-r.1-beta.3
 [5-r.1-beta.2]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.1-beta.1...5-r.1-beta.2

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/CubismCdiJson.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/CubismCdiJson.java
@@ -11,6 +11,8 @@ package com.live2d.sdk.cubism.framework;
 import com.live2d.sdk.cubism.framework.utils.jsonparser.ACubismJsonValue;
 import com.live2d.sdk.cubism.framework.utils.jsonparser.CubismJson;
 
+import java.util.List;
+
 /**
  * This class handles cdi.json data.
  */
@@ -144,12 +146,36 @@ public class CubismCdiJson {
         return json.getRoot().get(JsonKey.PARTS.key).get(index).get(JsonKey.NAME.key).getString();
     }
 
+    // ----- Combined Parameters -----//
+    /**
+     * Returns the number of combined parameters.
+     *
+     * @return number of combined parameters
+     */
+    public int getCombinedParametersCount() {
+        if (!existsCombinedParameters()) {
+            return 0;
+        }
+        return json.getRoot().get(JsonKey.COMBINED_PARAMETERS.key).size();
+    }
+
+    /**
+     * Returns the pair list of the combined parameter.
+     *
+     * @param index index to the desired combined parameters.
+     * @return pair list of the combined parameter
+     */
+    public List<ACubismJsonValue> getCombinedParameter(int index) {
+        return json.getRoot().get(JsonKey.COMBINED_PARAMETERS.key).get(index).getList();
+    }
+
     // JSON keys
     private enum JsonKey {
         VERSION("Version"),
         PARAMETERS("Parameters"),
         PARAMETER_GROUPS("ParameterGroups"),
         PARTS("Parts"),
+        COMBINED_PARAMETERS("CombinedParameters"),
         ID("Id"),
         GROUP_ID("GroupId"),
         NAME("Name");
@@ -192,6 +218,16 @@ public class CubismCdiJson {
      */
     private boolean existsParts() {
         ACubismJsonValue node = json.getRoot().get(JsonKey.PARTS.key);
+        return !node.isNull() && !node.isError();
+    }
+
+    /**
+     * Returns whether the combined parameters exist in the Display Information File(cdi3.json).
+     *
+     * @return If true, the key exists.
+     */
+    private boolean existsCombinedParameters() {
+        ACubismJsonValue node = json.getRoot().get(JsonKey.COMBINED_PARAMETERS.key);
         return !node.isNull() && !node.isError();
     }
 

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/effect/CubismPose.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/effect/CubismPose.java
@@ -273,6 +273,7 @@ public class CubismPose {
                 }
 
                 newOpacity = calculateOpacity(model, i, deltaTimeSeconds);
+
                 visiblePartIndex = i;
             }
         }
@@ -305,9 +306,13 @@ public class CubismPose {
      * @param model target model
      * @param index part index
      * @param deltaTime delta time[s]
-     * @return new calculated opacity
+     * @return new calculated opacity. If fade time is 0.0[s], return 1.0f.
      */
     private float calculateOpacity(CubismModel model, int index, float deltaTime) {
+        if (fadeTimeSeconds == 0) {
+            return 1.0f;
+        }
+
         final int partIndex = partGroups.get(index).partIndex;
         float opacity = model.getPartOpacity(partIndex);
 

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismUserModel.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismUserModel.java
@@ -23,6 +23,7 @@ import com.live2d.sdk.cubism.framework.motion.CubismExpressionMotionManager;
 import com.live2d.sdk.cubism.framework.motion.CubismMotion;
 import com.live2d.sdk.cubism.framework.motion.CubismMotionManager;
 import com.live2d.sdk.cubism.framework.motion.CubismMotionQueueManager;
+import com.live2d.sdk.cubism.framework.motion.IBeganMotionCallback;
 import com.live2d.sdk.cubism.framework.motion.ICubismMotionEventFunction;
 import com.live2d.sdk.cubism.framework.motion.IFinishedMotionCallback;
 import com.live2d.sdk.cubism.framework.physics.CubismPhysics;
@@ -321,14 +322,16 @@ public abstract class CubismUserModel {
      *
      * @param buffer a buffer where motion3.json file is loaded.
      * @param onFinishedMotionHandler the callback method called at finishing motion play. If it is null, callbacking methods is not conducting.
+     * @param onBeganMotionHandler the callback method called at beginning motion play. If it is null, callbacking methods is not conducting.
      * @return motion class
      */
     protected CubismMotion loadMotion(
         byte[] buffer,
-        IFinishedMotionCallback onFinishedMotionHandler
+        IFinishedMotionCallback onFinishedMotionHandler,
+        IBeganMotionCallback onBeganMotionHandler
     ) {
         try {
-            return CubismMotion.create(buffer, onFinishedMotionHandler);
+            return CubismMotion.create(buffer, onFinishedMotionHandler, onBeganMotionHandler);
         } catch (Exception e) {
             cubismLogError("Failed to loadMotion(). %s", e.getMessage());
             return null;
@@ -342,7 +345,7 @@ public abstract class CubismUserModel {
      * @return motion class
      */
     protected CubismMotion loadMotion(byte[] buffer) {
-        return loadMotion(buffer, null);
+        return loadMotion(buffer, null, null);
     }
 
     /**

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/ACubismMotion.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/ACubismMotion.java
@@ -216,11 +216,28 @@ public abstract class ACubismMotion {
      * @return list of events that have fired
      */
     public List<String> getFiredEvent(float beforeCheckTimeSeconds, float motionTimeSeconds) {
-        if (areFiredEventValuesChanged) {
-            cachedImmutableFiredEventValues = Collections.unmodifiableList(firedEventValues);
-            areFiredEventValuesChanged = false;
-        }
-        return cachedImmutableFiredEventValues;
+        return Collections.unmodifiableList(firedEventValues);
+    }
+
+    /**
+     * Registers a motion playback start callback.
+     * It is not called in the following states:
+     * 1. when the currently playing motion is set as "loop"
+     * 2. when null is registered in the callback
+     *
+     * @param onBeganMotionHandler start-of-motion playback callback function
+     */
+    public void setBeganMotionHandler(IBeganMotionCallback onBeganMotionHandler) {
+        onBeganMotion = onBeganMotionHandler;
+    }
+
+    /**
+     * Get the start-of-motion playback callback function.
+     *
+     * @return registered start-of-motion playback callback function; if null, no function is registered
+     */
+    public IBeganMotionCallback getBeganMotionCallback() {
+        return onBeganMotion;
     }
 
     /**
@@ -319,9 +336,10 @@ public abstract class ACubismMotion {
      */
     protected List<String> firedEventValues = new ArrayList<String>();
 
-    protected boolean areFiredEventValuesChanged = true;
-
-    protected List<String> cachedImmutableFiredEventValues;
+    /**
+     * Start-of-motion playback callback function
+     */
+    protected IBeganMotionCallback onBeganMotion;
 
     /**
      * End-of-motion playback callback function

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismMotionJson.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismMotionJson.java
@@ -14,7 +14,7 @@ import com.live2d.sdk.cubism.framework.utils.jsonparser.CubismJson;
 /**
  * Container for motion3.json.
  */
-class CubismMotionJson {
+public class CubismMotionJson {
     /**
      * Flag type of Bezier curve interpretation method
      */

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismMotionQueueManager.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismMotionQueueManager.java
@@ -46,6 +46,10 @@ public class CubismMotionQueueManager {
 
         motions.add(motionQueueEntry);
 
+        if (motion.onBeganMotion != null) {
+            motion.onBeganMotion.execute(motion);
+        }
+
         return System.identityHashCode(motionQueueEntry);
     }
 

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/IBeganMotionCallback.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/IBeganMotionCallback.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at http://live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+package com.live2d.sdk.cubism.framework.motion;
+
+/**
+ * モーション再生開始コールバック
+ */
+public interface IBeganMotionCallback {
+    void execute(ACubismMotion motion);
+}

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismRendererAndroid.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismRendererAndroid.java
@@ -444,7 +444,7 @@ public class CubismRendererAndroid extends CubismRenderer {
         glBindBuffer(GL_ARRAY_BUFFER, 0);
 
         // Anisotropic filtering. If it is not supported, do not set it
-        if (getAnisotropy() > 0.0f) {
+        if (getAnisotropy() >= 1.0f) {
             for (Map.Entry<Integer, Integer> entry : textures.entrySet()) {
                 glBindTexture(GL_TEXTURE_2D, entry.getValue());
                 glTexParameterf(GL_TEXTURE_2D, GLES11Ext.GL_TEXTURE_MAX_ANISOTROPY_EXT, getAnisotropy());


### PR DESCRIPTION
### Added

* Add function to get `CombinedParameters` listed in `cdi3.json`.
* Add the functionality to call a function when motion playback starts.

### Changed

* Change the access level of `CubismMotionJson` class to public.
* Change the threshold for enabling anisotropic filtering.

### Fixed

* Fix a bug in which a method to acquire events fired during motion playback returned incorrect values when called multiple times.
* Fix a potential problem with division by 0 when a pose fade time is set to 0 seconds.
* Fix a bug that thrown an exception when playing CubismExpresionMotion with CubismMotionQueueManager.startMotion().