### PR TITLE
Update to Cubism 5 SDK for Java R3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [5-r.3] - 2025-02-18
+
+### Added
+
+* Add new motion loop processing that seamlessly connects the start and end points of the loop.
+  * The `isLooped` variable has been moved from the `CubismMotion` class to the `ACubismMotion` class as `isLoop`.
+  * Add the setter for `isLoop`, `setLoop(boolean loop)`, to class `ACubismMotion`.
+  * Add the getter for `isLoop`, `getLoop()`, to class `ACubismMotion`.
+  * The `isLoopFadeIn` variable was moved from class `CubismMotion` to class `ACubismMotion`.
+  * Add the setter for `isLoopFadeIn`, `setLoopFadeIn(boolean loopFadeIn)`, to class `ACubismMotion`.
+  * Add the getter for `isLoopFadeIn`, `getLoopFadeIn()`, to class `ACubismMotion`.
+  * Add a variable `motionBehavior` for version control to the `CubismMotion` class.
+
+### Changed
+
+* Change the compile and target SDK version of Android OS to 15.0 (API 35).
+  * Upgrade the version of Android Gradle Plugin from 8.1.1 to 8.6.1.
+  * Upgrade the version of Gradle from 8.2 to 8.7.
+  * Change the minimum version of Android Studio to Ladybug(2024.2.1).
+* Change the arguments of `CsmMotionSegmentEvaluationFunction.evaluate` from `(float time, int basePointIndex)` to `(final List<CubismMotionPoint> points, final float time)` to align with the Cubism SDK for Native codebase.
+  * Accordingly, change the implementation of the following methods.
+    * CubismMotion.LinearEvaluator.evaluate()
+    * CubismMotion.BezierEvaluator.evaluate()
+    * CubismMotion.BezierEvaluatorCardanoInterpretation.evaluate()
+    * CubismMotion.SteppedEvaluator.evaluate()
+    * CubismMotion.InverseSteppedEvaluator.evaluate()
+    * CubismMotion.bezierEvaluateBinarySearch()
+* Change the access level of `CubismMotionQueueEntry` class to public.
+
+### Deprecated
+
+* Deprecate the following elements due to the change in the variable declaration location.
+  * `CubismMotion.isLoop(boolean loop)`
+  * `CubismMotion.isLoop()`
+  * `CubismMotion.isLoopFadeIn(boolean loopFadeIn)`
+  * `CubismMotion.isLoopFadeIn()`
+
+
 ## [5-r.2] - 2024-11-07
 
 ### Added
@@ -200,6 +238,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 * New released!
 
+
+[5-r.3]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.2...5-r.3
 [5-r.2]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.1...5-r.2
 [5-r.1]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.1-beta.3...5-r.1
 [5-r.1-beta.3]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.1-beta.2...5-r.1-beta.3

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.6.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/ACubismMotion.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/ACubismMotion.java
@@ -76,15 +76,9 @@ public abstract class ACubismMotion {
         // Record the start time of fade-in
         motionQueueEntry.setFadeInStartTime(userTimeSeconds);
 
-        final float duration = getDuration();
-
         // Deal with the case where the status is set "end" before it has started.
         if (motionQueueEntry.getEndTime() < 0) {
-            // If duration == -1, loop motion.
-            float endTime = (duration <= 0)
-                ? -1
-                : motionQueueEntry.getStartTime() + duration;
-            motionQueueEntry.setEndTime(endTime);
+            adjustEndTime(motionQueueEntry);
         }
     }
 
@@ -208,6 +202,42 @@ public abstract class ACubismMotion {
     }
 
     /**
+     * Sets whether the motion should loop.
+     *
+     * @param loop true to set the motion to loop
+     */
+    public void setLoop(boolean loop) {
+        isLoop = loop;
+    }
+
+    /**
+     * Checks whether the motion is set to loop.
+     *
+     * @return true if the motion is set to loop; otherwise false.
+     */
+    public boolean getLoop() {
+        return isLoop;
+    }
+
+    /**
+     * Sets whether to perform fade-in for looping motion.
+     *
+     * @param loopFadeIn true to perform fade-in for looping motion
+     */
+    public void setLoopFadeIn(boolean loopFadeIn) {
+        isLoopFadeIn = loopFadeIn;
+    }
+
+    /**
+     * Checks the setting for fade-in of looping motion.
+     *
+     * @return true if fade-in for looping motion is set; otherwise false.
+     */
+    public boolean getLoopFadeIn() {
+        return isLoopFadeIn;
+    }
+
+    /**
      * Check for event firing.
      * The input time reference is set to zero at the called motion timing.
      *
@@ -305,6 +335,17 @@ public abstract class ACubismMotion {
         CubismMotionQueueEntry motionQueueEntry
     );
 
+    protected void adjustEndTime(CubismMotionQueueEntry motionQueueEntry) {
+        final float duration = getDuration();
+
+        // duration == -1 の場合はループする
+        final float endTime = (duration <= 0)
+            ? -1
+            : motionQueueEntry.getStartTime() + duration;
+
+        motionQueueEntry.setEndTime(endTime);
+    }
+
     /**
      * 指定時間の透明度の値を返す。
      * NOTE: 更新後の値を取るには`updateParameters()` の後に呼び出す。
@@ -331,6 +372,20 @@ public abstract class ACubismMotion {
      * Start time for motion playback[s]
      */
     protected float offsetSeconds;
+
+    /**
+     * Enable/Disable loop
+     */
+    protected boolean isLoop;
+    /**
+     * flag whether fade-in is enabled at looping. Default value is true.
+     */
+    protected boolean isLoopFadeIn = true;
+
+    /**
+     * The previous state of `_isLoop`.
+     */
+    protected boolean previousLoopState = isLoop;
     /**
      * List of events that have fired
      */

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismMotionInternal.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismMotionInternal.java
@@ -68,6 +68,13 @@ class CubismMotionInternal {
          * value
          */
         public float value;
+
+        public CubismMotionPoint() {}
+
+        public CubismMotionPoint(final float time, final float value) {
+            this.time = time;
+            this.value = value;
+        }
     }
 
     /**
@@ -178,6 +185,6 @@ class CubismMotionInternal {
      * For strategy pattern.
      */
     public interface CsmMotionSegmentEvaluationFunction {
-        float evaluate(float time, int basePointIndex);
+        float evaluate(final List<CubismMotionPoint> points, final float time);
     }
 }

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismMotionQueueEntry.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismMotionQueueEntry.java
@@ -10,7 +10,7 @@ package com.live2d.sdk.cubism.framework.motion;
 /**
  * Manager class for each motion being played by CubismMotionQueueManager.
  */
-class CubismMotionQueueEntry {
+public class CubismMotionQueueEntry {
     /**
      * Get the motion.
      *

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,8 +18,8 @@ android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
 # Android SDK version that will be used as the compiled project
-PROP_COMPILE_SDK_VERSION=34
+PROP_COMPILE_SDK_VERSION=35
 # Android SDK version that will be used as the earliest version of android this application can run on
 PROP_MIN_SDK_VERSION=21
 # Android SDK version that will be used as the latest version of android this application has been tested on
-PROP_TARGET_SDK_VERSION=34
+PROP_TARGET_SDK_VERSION=35

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jul 11 18:25:17 JST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Added

* Add new motion loop processing that seamlessly connects the start and end points of the loop.
  * The `isLooped` variable has been moved from the `CubismMotion` class to the `ACubismMotion` class as `isLoop`.
  * Add the setter for `isLoop`, `setLoop(boolean loop)`, to class `ACubismMotion`.
  * Add the getter for `isLoop`, `getLoop()`, to class `ACubismMotion`.
  * The `isLoopFadeIn` variable was moved from class `CubismMotion` to class `ACubismMotion`.
  * Add the setter for `isLoopFadeIn`, `setLoopFadeIn(boolean loopFadeIn)`, to class `ACubismMotion`.
  * Add the getter for `isLoopFadeIn`, `getLoopFadeIn()`, to class `ACubismMotion`.
  * Add a variable `motionBehavior` for version control to the `CubismMotion` class.

### Changed

* Change the compile and target SDK version of Android OS to 15.0 (API 35).
  * Upgrade the version of Android Gradle Plugin from 8.1.1 to 8.6.1.
  * Upgrade the version of Gradle from 8.2 to 8.7.
  * Change the minimum version of Android Studio to Ladybug(2024.2.1).
* Change the arguments of `CsmMotionSegmentEvaluationFunction.evaluate` from `(float time, int basePointIndex)` to `(final List<CubismMotionPoint> points, final float time)` to align with the Cubism SDK for Native codebase.
  * Accordingly, change the implementation of the following methods.
    * CubismMotion.LinearEvaluator.evaluate()
    * CubismMotion.BezierEvaluator.evaluate()
    * CubismMotion.BezierEvaluatorCardanoInterpretation.evaluate()
    * CubismMotion.SteppedEvaluator.evaluate()
    * CubismMotion.InverseSteppedEvaluator.evaluate()
    * CubismMotion.bezierEvaluateBinarySearch()
* Change the access level of `CubismMotionQueueEntry` class to public.

### Deprecated

* Deprecate the following elements due to the change in the variable declaration location.
  * `CubismMotion.isLoop(boolean loop)`
  * `CubismMotion.isLoop()`
  * `CubismMotion.isLoopFadeIn(boolean loopFadeIn)`
  * `CubismMotion.isLoopFadeIn()`