### PR TITLE
Update to Cubism 5 SDK for Java R4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [5-r.4] - 2025-05-15
+
+### Added
+
+* Add an API to `CubismMotionJson` for verifying the consistency of `motion3.json`.
+* Add a flag to the arguments of the following methods to enable the function that verifies the consistency of `motion3.json`:
+  * `CubismUserModel.loadMotion()`
+  * `CubismMotion.create()`
+  * `CubismMotion.parse()`
+* Add parameter repeat processing that connects the right and left ends of the parameter to create a loop, allowing the motion to repeat.
+  * Add the variable `isOverriddenParameterRepeat` to the `CubismModel` class for managing parameter repeat flags at the model level.
+  * Add the variable `userParameterRepeatDataList` to the `CubismModel` class for managing parameter repeat flags for each parameter.
+* Add a `getPartParentPartIndices()` function.
+
+### Changed
+
+* Change the access level of the private members in the `CubismModelSettingJson` class to protected.
+* Change the default JDK version for compilation to 17 using Gradle's Java toolchain.
+
+### Fixed
+
+* Fix an issue in the `CubismPose` class where the opacity calculation for non-displayed parts differed from the implementation in the other Cubism SDK.
+
+
 ## [5-r.3] - 2025-02-18
 
 ### Added
@@ -52,6 +76,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+* Change an expression "overwrite" to "override" for multiply color, screen color, and culling to adapt the actual behavior.
 * Change the access level of `CubismMotionJson` class to public.
 * Change the threshold for enabling anisotropic filtering.
 
@@ -239,6 +264,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * New released!
 
 
+[5-r.4]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.3...5-r.4
 [5-r.3]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.2...5-r.3
 [5-r.2]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.1...5-r.2
 [5-r.1]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.1-beta.3...5-r.1

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -28,6 +28,12 @@ android {
     }
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 dependencies {
     compileOnly(fileTree(dir: '../../Core/android', include: ['Live2DCubismCore.aar']))
 

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/CubismModelSettingJson.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/CubismModelSettingJson.java
@@ -324,7 +324,7 @@ public class CubismModelSettingJson implements ICubismModelSetting {
     /**
      * Enum class for frequent nodes.
      */
-    private enum FrequentNode {
+    protected enum FrequentNode {
         GROUPS(0),
         MOC(1),
         MOTIONS(2),
@@ -335,14 +335,14 @@ public class CubismModelSettingJson implements ICubismModelSetting {
         POSE(7),
         HIT_AREAS(8);
 
-        private final int id;
+        protected final int id;
 
         FrequentNode(final int id) {
             this.id = id;
         }
     }
 
-    private enum JsonKey {
+    protected enum JsonKey {
         VERSION("Version"),
         FILE_REFERENCES("FileReferences"),
         GROUPS("Groups"),
@@ -392,7 +392,7 @@ public class CubismModelSettingJson implements ICubismModelSetting {
         INIT_PARTS_VISIBLE("init_parts_visible"),
         VAL("val");
 
-        private final String key;
+        protected final String key;
 
         JsonKey(String key) {
             this.key = key;
@@ -401,71 +401,71 @@ public class CubismModelSettingJson implements ICubismModelSetting {
 
 
     // キーが存在するかどうかのチェック
-    private boolean existsModelFile() {
+    protected boolean existsModelFile() {
         ACubismJsonValue node = jsonFrequencyValue.get(FrequentNode.MOC.id);
         return !node.isNull() && !node.isError();
     }
 
-    private boolean existsTextureFiles() {
+    protected boolean existsTextureFiles() {
         ACubismJsonValue node = jsonFrequencyValue.get(FrequentNode.TEXTURES.id);
         return !node.isNull() && !node.isError();
     }
 
-    private boolean existsHitAreas() {
+    protected boolean existsHitAreas() {
         ACubismJsonValue node = jsonFrequencyValue.get(FrequentNode.HIT_AREAS.id);
         return !node.isNull() && !node.isError();
     }
 
-    private boolean existsPhysicsFile() {
+    protected boolean existsPhysicsFile() {
         ACubismJsonValue node = jsonFrequencyValue.get(FrequentNode.PHYSICS.id);
         return !node.isNull() && !node.isError();
     }
 
-    private boolean existsPoseFile() {
+    protected boolean existsPoseFile() {
         ACubismJsonValue node = jsonFrequencyValue.get(FrequentNode.POSE.id);
         return !node.isNull() && !node.isError();
     }
 
-    private boolean existsDisplayInfoFile() {
+    protected boolean existsDisplayInfoFile() {
         ACubismJsonValue node = jsonFrequencyValue.get(FrequentNode.DISPLAY_INFO.id);
         return !node.isNull() && !node.isError();
     }
 
-    private boolean existsExpressionFile() {
+    protected boolean existsExpressionFile() {
         ACubismJsonValue node = jsonFrequencyValue.get(FrequentNode.EXPRESSIONS.id);
         return !node.isNull() && !node.isError();
     }
 
-    private boolean existsMotionGroups() {
+    protected boolean existsMotionGroups() {
         ACubismJsonValue node = jsonFrequencyValue.get(FrequentNode.MOTIONS.id);
         return !node.isNull() && !node.isError();
     }
 
-    private boolean existsMotionGroupName(String groupName) {
+    protected boolean existsMotionGroupName(String groupName) {
         ACubismJsonValue node = jsonFrequencyValue.get(FrequentNode.MOTIONS.id).get(groupName);
         return !node.isNull() && !node.isError();
     }
 
-    private boolean existsMotionSoundFile(String groupName, int index) {
+    protected boolean existsMotionSoundFile(String groupName, int index) {
         ACubismJsonValue node = jsonFrequencyValue.get(FrequentNode.MOTIONS.id).get(groupName).get(index).get(JsonKey.SOUND_PATH.key);
         return !node.isNull() && !node.isError();
     }
 
-    private boolean existsMotionFadeIn(String groupName, int index) {
+    protected boolean existsMotionFadeIn(String groupName, int index) {
         ACubismJsonValue node = jsonFrequencyValue.get(FrequentNode.MOTIONS.id).get(groupName).get(index).get(JsonKey.FADE_IN_TIME.key);
         return !node.isNull() && !node.isError();
     }
 
-    private boolean existsMotionFadeOut(String groupName, int index) {
+    protected boolean existsMotionFadeOut(String groupName, int index) {
         ACubismJsonValue node = jsonFrequencyValue.get(FrequentNode.MOTIONS.id).get(groupName).get(index).get(JsonKey.FADE_OUT_TIME.key);
         return !node.isNull() && !node.isError();
     }
 
-    private boolean existsUserDataFile() {
+    protected boolean existsUserDataFile() {
         return !json.getRoot().get(JsonKey.FILE_REFERENCES.key).get(JsonKey.USER_DATA.key).isNull();
     }
 
-    private boolean existsEyeBlinkParameters() {
+    protected boolean existsEyeBlinkParameters() {
         if (jsonFrequencyValue.get(FrequentNode.GROUPS.id).isNull() || jsonFrequencyValue.get(FrequentNode.GROUPS.id).isError()) {
             return false;
         }
@@ -479,7 +479,7 @@ public class CubismModelSettingJson implements ICubismModelSetting {
         return false;
     }
 
-    private boolean existsLipSyncParameters() {
+    protected boolean existsLipSyncParameters() {
         if (jsonFrequencyValue.get(FrequentNode.GROUPS.id).isNull() || jsonFrequencyValue.get(FrequentNode.GROUPS.id).isError()) {
             return false;
         }
@@ -495,9 +495,9 @@ public class CubismModelSettingJson implements ICubismModelSetting {
     /**
      * model3.json data
      */
-    private final CubismJson json;
+    protected final CubismJson json;
     /**
      * Frequent nodes in the _json data
      */
-    private List<ACubismJsonValue> jsonFrequencyValue;
+    protected List<ACubismJsonValue> jsonFrequencyValue;
 }

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/effect/CubismPose.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/effect/CubismPose.java
@@ -339,7 +339,7 @@ public class CubismPose {
         float a1; // opacity to be calculated
         if (newOpacity < PHI) {
             // Linear equation passing through (0,1),(PHI,PHI)
-            a1 = newOpacity * (PHI - 1.0f) / (PHI + 1.0f);
+            a1 = newOpacity * (PHI - 1) / PHI + 1.0f;
         } else {
             a1 = (1 - newOpacity) * PHI / (1.0f - PHI);
         }

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/math/CubismMath.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/math/CubismMath.java
@@ -16,6 +16,16 @@ public class CubismMath {
     public static final float PI = 3.1415926535897932384626433832795f;
     public static final float EPSILON = 0.00001f;
 
+    public static float clampF(float val, float min, float max) {
+        if (val < min) {
+            return min;
+        } else if (max < val) {
+            return max;
+        }
+
+        return val;
+    }
+
     /**
      * Returns the value of the first argument in the range of minimum and maximum values.
      *

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismUserModel.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismUserModel.java
@@ -323,15 +323,17 @@ public abstract class CubismUserModel {
      * @param buffer a buffer where motion3.json file is loaded.
      * @param onFinishedMotionHandler the callback method called at finishing motion play. If it is null, callbacking methods is not conducting.
      * @param onBeganMotionHandler the callback method called at beginning motion play. If it is null, callbacking methods is not conducting.
+     * @param shouldCheckMotionConsistency flag to validate the consistency of motion3.json.
      * @return motion class
      */
     protected CubismMotion loadMotion(
         byte[] buffer,
         IFinishedMotionCallback onFinishedMotionHandler,
-        IBeganMotionCallback onBeganMotionHandler
+        IBeganMotionCallback onBeganMotionHandler,
+        boolean shouldCheckMotionConsistency
     ) {
         try {
-            return CubismMotion.create(buffer, onFinishedMotionHandler, onBeganMotionHandler);
+            return CubismMotion.create(buffer, onFinishedMotionHandler, onBeganMotionHandler, shouldCheckMotionConsistency);
         } catch (Exception e) {
             cubismLogError("Failed to loadMotion(). %s", e.getMessage());
             return null;
@@ -340,12 +342,49 @@ public abstract class CubismUserModel {
 
     /**
      * Load a motion data.
+     * This method does not check the consistency of motion3.json.
+     * To check the consistency of motion3.json,
+     * use {@link #loadMotion(byte[], IFinishedMotionCallback, IBeganMotionCallback, boolean)}
+     * and set the fourth argument to `true`.
+     *
+     * @param buffer a buffer where motion3.json file is loaded.
+     * @param onFinishedMotionHandler the callback method called at finishing motion play. If it is null, callbacking methods is not conducting.
+     * @param onBeganMotionHandler the callback method called at beginning motion play. If it is null, callbacking methods is not conducting.
+     * @return motion class
+     */
+    protected CubismMotion loadMotion(
+        byte[] buffer,
+        IFinishedMotionCallback onFinishedMotionHandler,
+        IBeganMotionCallback onBeganMotionHandler
+    ) {
+        return loadMotion(buffer, onFinishedMotionHandler, onBeganMotionHandler, false);
+    }
+
+    /**
+     * Load a motion data.
+     * This method does not set any callback functions.
+     *
+     * @param buffer                       a buffer where motion3.json file is loaded.
+     * @param shouldCheckMotionConsistency flag to validate the consistency of motion3.json.
+     * @return motion class
+     */
+    protected CubismMotion loadMotion(byte[] buffer, boolean shouldCheckMotionConsistency) {
+        return loadMotion(buffer, null, null, shouldCheckMotionConsistency);
+    }
+
+    /**
+     * Load a motion data.
+     * This method does not check the consistency of motion3.json.
+     * To check the consistency of motion3.json,
+     * use {@link #loadMotion(byte[], boolean)}
+     * and set the second argument to `true`.
+     * This method does not set any callback functions.
      *
      * @param buffer a buffer where motion3.json file is loaded.
      * @return motion class
      */
     protected CubismMotion loadMotion(byte[] buffer) {
-        return loadMotion(buffer, null, null);
+        return loadMotion(buffer, null, null, false);
     }
 
     /**
@@ -493,6 +532,10 @@ public abstract class CubismUserModel {
      * MOC3の整合性を検証するか。検証するならtrue。
      */
     protected boolean mocConsistency;
+    /**
+     * motion3.jsonの整合性を検証するか。検証するならtrue。
+     */
+    protected boolean motionConsistency;
     /**
      * Whether it is debug mode
      */

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.10.0'
+}
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
### Added

* Add an API to `CubismMotionJson` for verifying the consistency of `motion3.json`.
* Add a flag to the arguments of the following methods to enable the function that verifies the consistency of `motion3.json`:
  * `CubismUserModel.loadMotion()`
  * `CubismMotion.create()`
  * `CubismMotion.parse()`
* Add parameter repeat processing that connects the right and left ends of the parameter to create a loop, allowing the motion to repeat.
  * Add the variable `isOverriddenParameterRepeat` to the `CubismModel` class for managing parameter repeat flags at the model level.
  * Add the variable `userParameterRepeatDataList` to the `CubismModel` class for managing parameter repeat flags for each parameter.
* Add a `getPartParentPartIndices()` function.

### Changed

* Change the access level of the private members in the `CubismModelSettingJson` class to protected.
* Change the default JDK version for compilation to 17 using Gradle's Java toolchain.

### Fixed

* Fix an issue in the `CubismPose` class where the opacity calculation for non-displayed parts differed from the implementation in the other Cubism SDK.