### PR TITLE
Update to Cubism 5 SDK for Java R5 beta1_1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [5-r.5-beta.1.1] - 2026-02-19
+
+### Fixed
+
+* Fix clipping mask pre-processing by consolidating functions.
+* Fix a bug where offscreen rendering results were not as expected when premultiplied alpha was disabled.
+* Fix a bug where rendering results were not as expected when using Blend mode on semi-transparent objects.
+
+
 ## [5-r.5-beta.1] - 2026-01-29
 
 ### Added
@@ -292,6 +301,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * New released!
 
 
+[5-r.5-beta.1.1]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.5-beta.1...5-r.5-beta.1.1
 [5-r.5-beta.1]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.4.1...5-r.5-beta.1
 [5-r.4.1]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.4...5-r.4.1
 [5-r.4]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.3...5-r.4

--- a/framework/src/main/assets/com/live2d/sdk/cubism/framework/shaders/standardES/FragShaderSrcMaskBlend.frag
+++ b/framework/src/main/assets/com/live2d/sdk/cubism/framework/shaders/standardES/FragShaderSrcMaskBlend.frag
@@ -32,7 +32,7 @@ void main()
     vec4 col_formask = texColor * u_baseColor;
     vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
-    vec4 colorSource = col_formask * maskVal;
+    vec4 colorSource = vec4(col_formask.rgb, col_formask.a * maskVal);
     vec4 colorDestination = ConvertPremultipliedToStraight(texture2D(s_blendTexture, v_blendCoord));
     gl_FragColor = AlphaBlend(ColorBlend(colorSource.rgb, colorDestination.rgb), colorSource, colorDestination);
 }

--- a/framework/src/main/assets/com/live2d/sdk/cubism/framework/shaders/standardES/FragShaderSrcMaskBlendTegra.frag
+++ b/framework/src/main/assets/com/live2d/sdk/cubism/framework/shaders/standardES/FragShaderSrcMaskBlendTegra.frag
@@ -33,7 +33,7 @@ void main()
     vec4 col_formask = texColor * u_baseColor;
     vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
-    vec4 colorSource = col_formask * maskVal;
+    vec4 colorSource = vec4(col_formask.rgb, col_formask.a * maskVal);
     vec4 colorDestination = ConvertPremultipliedToStraight(texture2D(s_blendTexture, v_blendCoord));
     gl_FragColor = AlphaBlend(ColorBlend(colorSource.rgb, colorDestination.rgb), colorSource, colorDestination);
 }

--- a/framework/src/main/assets/com/live2d/sdk/cubism/framework/shaders/standardES/FragShaderSrcMaskInvertedBlend.frag
+++ b/framework/src/main/assets/com/live2d/sdk/cubism/framework/shaders/standardES/FragShaderSrcMaskInvertedBlend.frag
@@ -32,7 +32,7 @@ void main()
     vec4 col_formask = texColor * u_baseColor;
     vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
-    vec4 colorSource = col_formask * (1.0 - maskVal);
+    vec4 colorSource = vec4(col_formask.rgb, col_formask.a * (1.0 - maskVal));
     vec4 colorDestination = ConvertPremultipliedToStraight(texture2D(s_blendTexture, v_blendCoord));
     gl_FragColor = AlphaBlend(ColorBlend(colorSource.rgb, colorDestination.rgb), colorSource, colorDestination);
 }

--- a/framework/src/main/assets/com/live2d/sdk/cubism/framework/shaders/standardES/FragShaderSrcMaskInvertedBlendTegra.frag
+++ b/framework/src/main/assets/com/live2d/sdk/cubism/framework/shaders/standardES/FragShaderSrcMaskInvertedBlendTegra.frag
@@ -33,7 +33,7 @@ void main()
     vec4 col_formask = texColor * u_baseColor;
     vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
-    vec4 colorSource = col_formask * (1.0 - maskVal);
+    vec4 colorSource = vec4(col_formask.rgb, col_formask.a * (1.0 - maskVal));
     vec4 colorDestination = ConvertPremultipliedToStraight(texture2D(s_blendTexture, v_blendCoord));
     gl_FragColor = AlphaBlend(ColorBlend(colorSource.rgb, colorDestination.rgb), colorSource, colorDestination);
 }

--- a/framework/src/main/assets/com/live2d/sdk/cubism/framework/shaders/standardES/FragShaderSrcMaskInvertedPremultipliedAlphaBlend.frag
+++ b/framework/src/main/assets/com/live2d/sdk/cubism/framework/shaders/standardES/FragShaderSrcMaskInvertedPremultipliedAlphaBlend.frag
@@ -32,7 +32,7 @@ void main()
     vec4 col_formask = ConvertPremultipliedToStraight(texColor * u_baseColor);
     vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
-    vec4 colorSource = col_formask * (1.0 - maskVal);
+    vec4 colorSource = vec4(col_formask.rgb, col_formask.a * (1.0 - maskVal));
     vec4 colorDestination = ConvertPremultipliedToStraight(texture2D(s_blendTexture, v_blendCoord));
     gl_FragColor = AlphaBlend(ColorBlend(colorSource.rgb, colorDestination.rgb), colorSource, colorDestination);
 }

--- a/framework/src/main/assets/com/live2d/sdk/cubism/framework/shaders/standardES/FragShaderSrcMaskInvertedPremultipliedAlphaBlendTegra.frag
+++ b/framework/src/main/assets/com/live2d/sdk/cubism/framework/shaders/standardES/FragShaderSrcMaskInvertedPremultipliedAlphaBlendTegra.frag
@@ -33,7 +33,7 @@ void main()
     vec4 col_formask = ConvertPremultipliedToStraight(texColor * u_baseColor);
     vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
-    vec4 colorSource = col_formask * (1.0 - maskVal);
+    vec4 colorSource = vec4(col_formask.rgb, col_formask.a * (1.0 - maskVal));
     vec4 colorDestination = ConvertPremultipliedToStraight(texture2D(s_blendTexture, v_blendCoord));
     gl_FragColor = AlphaBlend(ColorBlend(colorSource.rgb, colorDestination.rgb), colorSource, colorDestination);
 }

--- a/framework/src/main/assets/com/live2d/sdk/cubism/framework/shaders/standardES/FragShaderSrcMaskPremultipliedAlphaBlend.frag
+++ b/framework/src/main/assets/com/live2d/sdk/cubism/framework/shaders/standardES/FragShaderSrcMaskPremultipliedAlphaBlend.frag
@@ -32,7 +32,7 @@ void main()
     vec4 col_formask = ConvertPremultipliedToStraight(texColor * u_baseColor);
     vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
-    vec4 colorSource = col_formask * maskVal;
+    vec4 colorSource = vec4(col_formask.rgb, col_formask.a * maskVal);
     vec4 colorDestination = ConvertPremultipliedToStraight(texture2D(s_blendTexture, v_blendCoord));
     gl_FragColor = AlphaBlend(ColorBlend(colorSource.rgb, colorDestination.rgb), colorSource, colorDestination);
 }

--- a/framework/src/main/assets/com/live2d/sdk/cubism/framework/shaders/standardES/FragShaderSrcMaskPremultipliedAlphaBlendTegra.frag
+++ b/framework/src/main/assets/com/live2d/sdk/cubism/framework/shaders/standardES/FragShaderSrcMaskPremultipliedAlphaBlendTegra.frag
@@ -33,7 +33,7 @@ void main()
     vec4 col_formask = ConvertPremultipliedToStraight(texColor * u_baseColor);
     vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
-    vec4 colorSource = col_formask * maskVal;
+    vec4 colorSource = vec4(col_formask.rgb, col_formask.a * maskVal);
     vec4 colorDestination = ConvertPremultipliedToStraight(texture2D(s_blendTexture, v_blendCoord));
     gl_FragColor = AlphaBlend(ColorBlend(colorSource.rgb, colorDestination.rgb), colorSource, colorDestination);
 }

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/ACubismClippingManager.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/ACubismClippingManager.java
@@ -66,7 +66,7 @@ public abstract class ACubismClippingManager<
     @Override
     public void close() {
         clippingContextListForMask.clear();
-        clippingContextListForDrawable.clear();
+        clippingContextListForDraw.clear();
         clippingContextListForOffscreen.clear();
 
         channelColors.clear();
@@ -77,249 +77,172 @@ public abstract class ACubismClippingManager<
     }
 
     @Override
-    public void initializeForDrawable(
+    public void initialize(
         CubismRenderer.RendererType type,
         CubismModel model,
-        int maskBufferCount
+        int maskBufferCount,
+        CubismRenderer.DrawableObjectType drawableObjectType
     ) {
         renderTextureCount = maskBufferCount;
 
         // レンダーテクスチャのクリアフラグの配列の初期化
         clearedMaskBufferFlags = new boolean[renderTextureCount];
 
-        final int drawableCount = model.getDrawableCount();     // 描画オブジェクトの数
-        final int[][] drawableMasks = model.getDrawableMasks();     // 描画オブジェクトをマスクする描画オブジェクトのインデックスのリスト
-        final int[] drawableMaskCounts = model.getDrawableMaskCounts();     // 描画オブジェクトをマスクする描画オブジェクトの数
+        int objectCount = 0;        //オブジェクトの数
+        int[][] objectMasks;        // オブジェクトをマスクするオブジェクトのインデックスのリスト
+        int[] objectMaskCounts;     //オブジェクトをマスクするオブジェクトの数
+        List<T_ClippingContext> objectClippingContextList;
+
+        switch (drawableObjectType) {
+            case DRAWABLE:
+            default:
+                objectCount = model.getDrawableCount();
+                objectMasks = model.getDrawableMasks();
+                objectMaskCounts = model.getDrawableMaskCounts();
+                objectClippingContextList = clippingContextListForDraw;
+                break;
+            case OFFSCREEN:
+                objectCount = model.getOffscreenCount();
+                objectMasks = model.getOffscreenMasks();
+                objectMaskCounts = model.getOffscreenMaskCounts();
+                objectClippingContextList = clippingContextListForOffscreen;
+                break;
+        }
 
         // クリッピングマスクを使う描画オブジェクトを全て登録する。
         // クリッピングマスクは、通常数個程度に限定して使うものとする。
-        for (int i = 0; i < drawableCount; i++) {
-            if (drawableMaskCounts[i] <= 0) {
-                // クリッピングマスクが使用されていないアートメッシュ（多くの場合使用しない）
-                clippingContextListForDrawable.add(null);
+        for (int i = 0; i < objectCount; i++) {
+            if (objectMaskCounts[i] <= 0) {
+                // クリッピングマスクが使用されていない描画オブジェクト（多くの場合使用しない）
+                objectClippingContextList.add(null);
                 continue;
             }
 
             // 既にあるClipContextと同じかチェックする。
-            T_ClippingContext cc = findSameClip(drawableMasks[i], drawableMaskCounts[i]);
+            T_ClippingContext cc = findSameClip(objectMasks[i], objectMaskCounts[i]);
             if (cc == null) {
                 // 同一のマスクが存在していない場合は生成する。
                 cc = (T_ClippingContext) ACubismClippingContext.createClippingContext(
                     type,
                     this,
-                    drawableMasks[i],
-                    drawableMaskCounts[i]
+                    objectMasks[i],
+                    objectMaskCounts[i]
                 );
 
                 clippingContextListForMask.add(cc);
             }
 
-            cc.addClippedDrawable(i);
-            clippingContextListForDrawable.add(cc);
+            switch (drawableObjectType) {
+                case DRAWABLE:
+                default:
+                     cc.addClippedDrawable(i);
+                    break;
+                case OFFSCREEN:
+                    cc.addClippedOffscreen(i);
+                    break;
+            }
+
+            objectClippingContextList.add(cc);
         }
     }
 
     @Override
-    public void initializeForOffscreen(
-        CubismRenderer.RendererType type,
+    public void setupMatrixForHighPrecision(
         CubismModel model,
-        int maskBufferCount
+        boolean isRightHanded,
+        CubismRenderer.DrawableObjectType drawableObjectType,
+        final CubismMatrix44 mvp
     ) {
-        renderTextureCount = maskBufferCount;
+        // 全てのクリッピングを用意する。
+        // 同じクリップ（複数の場合はまとめて1つのクリップ）を使う場合は1度だけ設定する。
+        int usingClipCount = 0;
+        for (int clipIndex = 0; clipIndex < clippingContextListForMask.size(); clipIndex++) {
+            // 1つのクリッピングマスクに関して
+            T_ClippingContext cc = clippingContextListForMask.get(clipIndex);
 
-        // レンダーテクスチャのクリアフラグの配列の初期化
-        clearedMaskBufferFlags = new boolean[renderTextureCount];
+            // このクリップを利用する描画オブジェクト群全体を囲む矩形を計算
+            calcClippedTotalBounds(model, cc, drawableObjectType);
 
-        final int offscreenCount = model.getOffscreenCount();
-        final int[][] offscreenMasks = model.getOffscreenMasks();
-        final int[] offscreenMaskCounts = model.getOffscreenMaskCounts();
+            if (cc.isUsing) {
+                usingClipCount++;   // 使用中としてカウント
+            }
+        }
 
-        // クリッピングマスクを使うオフスクリーンを全て登録する。
-        // クリッピングマスクは、通常数個程度に限定して使うものとする。
-        for (int i = 0; i < offscreenCount; i++) {
-            if (offscreenMaskCounts[i] <= 0) {
-                // クリッピングマスクが使用されていないオフスクリーン（多くの場合使用しない）
-                clippingContextListForOffscreen.add(null);
-                continue;
+        // マスク行列作成処理
+        if (usingClipCount <= 0) {
+            return;     // クリッピングマスクが存在しない場合何もしない。
+        }
+
+        setupLayoutBounds(0);
+
+        // サイズがレンダーテクスチャの枚数と合わない場合は合わせる。
+        if (clearedMaskBufferFlags.length != renderTextureCount) {
+            clearedMaskBufferFlags = new boolean[renderTextureCount];
+        }
+        // マスクのクリアフラグを毎フレーム開始時に初期化する。
+        else {
+            for (int i = 0; i < renderTextureCount; i++) {
+                clearedMaskBufferFlags[i] = false;
+            }
+        }
+
+        // 実際にマスクを生成する。
+        // 全てのマスクをどのようにレイアウトして描くかを決定し、ClipContext, ClippedDrawContextに記憶する。
+        for (int clipIndex = 0; clipIndex < clippingContextListForMask.size(); clipIndex++) {
+            // ---- 実際に1つのマスクを描く ----
+            T_ClippingContext clipContext = clippingContextListForMask.get(clipIndex);
+            csmRectF allClippedDrawRect = clipContext.allClippedDrawRect;   // このマスクを使う、全ての描画オブジェクトの論理座標上の囲み矩形
+            csmRectF layoutBoundsOnTex01 = clipContext.layoutBounds;    // このマスクを収める
+
+            final float margin = 0.05f;
+            float scaleX, scaleY;
+            final float ppu = model.getPixelPerUnit();
+            final float maskPixelWidth = clipContext.getClippingManager().getClippingMaskBufferSize().x;
+            final float maskPixelHeight = clipContext.getClippingManager().getClippingMaskBufferSize().y;
+            final float physicalMaskWidth = layoutBoundsOnTex01.getWidth() * maskPixelWidth;
+            final float physicalMaskHeight = layoutBoundsOnTex01.getHeight() * maskPixelHeight;
+
+            tmpBoundsOnModel.setRect(allClippedDrawRect);
+
+            if (tmpBoundsOnModel.getWidth() * ppu > physicalMaskWidth) {
+                tmpBoundsOnModel.expand(allClippedDrawRect.getWidth() * margin, 0.0f);
+                scaleX = layoutBoundsOnTex01.getWidth() / tmpBoundsOnModel.getWidth();
+            } else {
+                scaleX = ppu / physicalMaskWidth;
             }
 
-            // 既にあるClipContextと同じかチェックする。
-            T_ClippingContext cc = findSameClip(offscreenMasks[i], offscreenMaskCounts[i]);
-            if (cc == null) {
-                // 同一のマスクが存在していない場合は生成する。
-                cc = (T_ClippingContext) ACubismClippingContext.createClippingContext(
-                    type,
-                    this,
-                    offscreenMasks[i],
-                    offscreenMaskCounts[i]
+            if (tmpBoundsOnModel.getHeight() * ppu > physicalMaskHeight) {
+                tmpBoundsOnModel.expand(0.0f, allClippedDrawRect.getHeight() * margin);
+                scaleY = layoutBoundsOnTex01.getHeight() / tmpBoundsOnModel.getHeight();
+            } else {
+                scaleY = ppu / physicalMaskHeight;
+            }
+
+            // マスク生成時に使う行列を求める。
+            createMatrixForMask(isRightHanded, layoutBoundsOnTex01, scaleX, scaleY);
+
+            clipContext.matrixForMask.setMatrix(tmpMatrixForMask.getArray());
+            clipContext.matrixForDraw.setMatrix(tmpMatrixForDraw.getArray());
+
+            if (drawableObjectType == CubismRenderer.DrawableObjectType.OFFSCREEN) {
+                // mvp^-1 * clipContext
+                mvp.getInvert(reusableMatrix);
+                CubismMatrix44.multiply(
+                    reusableMatrix.getArray(),
+                    clipContext.matrixForDraw.getArray(),
+                    clipContext.matrixForDraw.getArray()
                 );
-
-                clippingContextListForMask.add(cc);
             }
-
-            cc.addClippedOffscreen(i);
-
-            clippingContextListForOffscreen.add(cc);
         }
     }
 
     @Override
-    public void setupMatrixForDrawableHighPrecision(CubismModel model, boolean isRightHanded) {
-        // 全てのクリッピングを用意する。
-        // 同じクリップ（複数の場合はまとめて1つのクリップ）を使う場合は1度だけ設定する。
-        int usingClipCount = 0;
-        for (int clipIndex = 0; clipIndex < clippingContextListForMask.size(); clipIndex++) {
-            // 1つのクリッピングマスクに関して
-            T_ClippingContext cc = clippingContextListForMask.get(clipIndex);
-
-            // このクリップを利用する描画オブジェクト群全体を囲む矩形を計算
-            calcClippedDrawableTotalBounds(model, cc);
-
-            if (cc.isUsing) {
-                usingClipCount++;   // 使用中としてカウント
-            }
-        }
-
-        // マスク行列作成処理
-        if (usingClipCount <= 0) {
-            return;     // クリッピングマスクが存在しない場合何もしない。
-        }
-
-        setupLayoutBounds(0);
-
-        // サイズがレンダーテクスチャの枚数と合わない場合は合わせる。
-        if (clearedMaskBufferFlags.length != renderTextureCount) {
-            clearedMaskBufferFlags = new boolean[renderTextureCount];
-        }
-        // マスクのクリアフラグを毎フレーム開始時に初期化する。
-        else {
-            for (int i = 0; i < renderTextureCount; i++) {
-                clearedMaskBufferFlags[i] = false;
-            }
-        }
-
-        // 実際にマスクを生成する。
-        // 全てのマスクをどのようにレイアウトして描くかを決定し、ClipContext, ClippedDrawContextに記憶する。
-        for (int clipIndex = 0; clipIndex < clippingContextListForMask.size(); clipIndex++) {
-            // ---- 実際に1つのマスクを描く ----
-            T_ClippingContext clipContext = clippingContextListForMask.get(clipIndex);
-            csmRectF allClippedDrawRect = clipContext.allClippedDrawRect;   // このマスクを使う、全ての描画オブジェクトの論理座標上の囲み矩形
-            csmRectF layoutBoundsOnTex01 = clipContext.layoutBounds;    // このマスクを収める
-
-            final float margin = 0.05f;
-            float scaleX, scaleY;
-            final float ppu = model.getPixelPerUnit();
-            final float maskPixelWidth = clipContext.getClippingManager().getClippingMaskBufferSize().x;
-            final float maskPixelHeight = clipContext.getClippingManager().getClippingMaskBufferSize().y;
-            final float physicalMaskWidth = layoutBoundsOnTex01.getWidth() * maskPixelWidth;
-            final float physicalMaskHeight = layoutBoundsOnTex01.getHeight() * maskPixelHeight;
-
-            tmpBoundsOnModel.setRect(allClippedDrawRect);
-
-            if (tmpBoundsOnModel.getWidth() * ppu > physicalMaskWidth) {
-                tmpBoundsOnModel.expand(allClippedDrawRect.getWidth() * margin, 0.0f);
-                scaleX = layoutBoundsOnTex01.getWidth() / tmpBoundsOnModel.getWidth();
-            } else {
-                scaleX = ppu / physicalMaskWidth;
-            }
-
-            if (tmpBoundsOnModel.getHeight() * ppu > physicalMaskHeight) {
-                tmpBoundsOnModel.expand(0.0f, allClippedDrawRect.getHeight() * margin);
-                scaleY = layoutBoundsOnTex01.getHeight() / tmpBoundsOnModel.getHeight();
-            } else {
-                scaleY = ppu / physicalMaskHeight;
-            }
-
-            // マスク生成時に使う行列を求める。
-            createMatrixForMask(isRightHanded, layoutBoundsOnTex01, scaleX, scaleY);
-
-            clipContext.matrixForMask.setMatrix(tmpMatrixForMask.getArray());
-            clipContext.matrixForDraw.setMatrix(tmpMatrixForDraw.getArray());
-        }
-    }
-
-    @Override
-    public void setupMatrixForOffscreenHighPrecision(CubismModel model, boolean isRightHanded, final CubismMatrix44 mvp) {
-        // 全てのクリッピングを用意する。
-        // 同じクリップ（複数の場合はまとめて1つのクリップ）を使う場合は1度だけ設定する。
-        int usingClipCount = 0;
-        for (int clipIndex = 0; clipIndex < clippingContextListForMask.size(); clipIndex++) {
-            // 1つのクリッピングマスクに関して
-            T_ClippingContext cc = clippingContextListForMask.get(clipIndex);
-
-            // このクリップを利用する描画オブジェクト群全体を囲む矩形を計算
-            calcClippedOffscreenTotalBounds(model, cc);
-
-            if (cc.isUsing) {
-                usingClipCount++;   // 使用中としてカウント
-            }
-        }
-
-        // マスク行列作成処理
-        if (usingClipCount <= 0) {
-            return;     // クリッピングマスクが存在しない場合何もしない。
-        }
-
-        setupLayoutBounds(0);
-
-        // サイズがレンダーテクスチャの枚数と合わない場合は合わせる。
-        if (clearedMaskBufferFlags.length != renderTextureCount) {
-            clearedMaskBufferFlags = new boolean[renderTextureCount];
-        }
-        // マスクのクリアフラグを毎フレーム開始時に初期化する。
-        else {
-            for (int i = 0; i < renderTextureCount; i++) {
-                clearedMaskBufferFlags[i] = false;
-            }
-        }
-
-        // 実際にマスクを生成する。
-        // 全てのマスクをどのようにレイアウトして描くかを決定し、ClipContext, ClippedDrawContextに記憶する。
-        for (int clipIndex = 0; clipIndex < clippingContextListForMask.size(); clipIndex++) {
-            // ---- 実際に1つのマスクを描く ----
-            T_ClippingContext clipContext = clippingContextListForMask.get(clipIndex);
-            csmRectF allClippedDrawRect = clipContext.allClippedDrawRect;   // このマスクを使う、全ての描画オブジェクトの論理座標上の囲み矩形
-            csmRectF layoutBoundsOnTex01 = clipContext.layoutBounds;    // このマスクを収める
-
-            final float margin = 0.05f;
-            float scaleX, scaleY;
-            final float ppu = model.getPixelPerUnit();
-            final float maskPixelWidth = clipContext.getClippingManager().getClippingMaskBufferSize().x;
-            final float maskPixelHeight = clipContext.getClippingManager().getClippingMaskBufferSize().y;
-            final float physicalMaskWidth = layoutBoundsOnTex01.getWidth() * maskPixelWidth;
-            final float physicalMaskHeight = layoutBoundsOnTex01.getHeight() * maskPixelHeight;
-
-            tmpBoundsOnModel.setRect(allClippedDrawRect);
-
-            if (tmpBoundsOnModel.getWidth() * ppu > physicalMaskWidth) {
-                tmpBoundsOnModel.expand(allClippedDrawRect.getWidth() * margin, 0.0f);
-                scaleX = layoutBoundsOnTex01.getWidth() / tmpBoundsOnModel.getWidth();
-            } else {
-                scaleX = ppu / physicalMaskWidth;
-            }
-
-            if (tmpBoundsOnModel.getHeight() * ppu > physicalMaskHeight) {
-                tmpBoundsOnModel.expand(0.0f, allClippedDrawRect.getHeight() * margin);
-                scaleY = layoutBoundsOnTex01.getHeight() / tmpBoundsOnModel.getHeight();
-            } else {
-                scaleY = ppu / physicalMaskHeight;
-            }
-
-            // マスク生成時に使う行列を求める。
-            createMatrixForMask(isRightHanded, layoutBoundsOnTex01, scaleX, scaleY);
-
-            clipContext.matrixForMask.setMatrix(tmpMatrixForMask.getArray());
-            clipContext.matrixForDraw.setMatrix(tmpMatrixForDraw.getArray());
-
-            // mvp^-1 * clipContext
-            mvp.getInvert(reusableMatrix);
-
-            CubismMatrix44.multiply(
-                reusableMatrix.getArray(),
-                clipContext.matrixForDraw.getArray(),
-                clipContext.matrixForDraw.getArray()
-            );
-        }
+    public void setupMatrixForHighPrecision(
+        CubismModel model,
+        boolean isRightHanded,
+        CubismRenderer.DrawableObjectType drawableObjectType
+    ) {
+        setupMatrixForHighPrecision(model, isRightHanded, drawableObjectType, CubismMatrix44.create());
     }
 
     @Override
@@ -586,12 +509,17 @@ public abstract class ACubismClippingManager<
     }
 
     /**
-     * マスクされるdrawableの描画オブジェクト群全体を囲む矩形（モデル座標系）を計算する。
+     * マスクされる描画オブジェクト群全体を囲む矩形（モデル座標系）を計算する。
      *
-     * @param model           モデルのインスタンス
-     * @param clippingContext クリッピングマスクのコンテキスト
+     * @param model              モデルのインスタンス
+     * @param clippingContext    クリッピングマスクのコンテキスト
+     * @param drawableObjectType 処理するオブジェクトタイプ
      */
-    public void calcClippedDrawableTotalBounds(CubismModel model, T_ClippingContext clippingContext) {
+    public void calcClippedTotalBounds(
+        CubismModel model,
+        T_ClippingContext clippingContext,
+        CubismRenderer.DrawableObjectType drawableObjectType
+    ) {
         // 被クリッピングマスク（マスクされる描画オブジェクト）の全体の矩形
         float clippedDrawTotalMinX = Float.MAX_VALUE;
         float clippedDrawTotalMinY = Float.MAX_VALUE;
@@ -600,92 +528,44 @@ public abstract class ACubismClippingManager<
 
         // このマスクが実際に必要か判定する。
         // このクリッピングを利用する「描画オブジェクト」がひとつでも使用可能であればマスクを生成する必要がある。
-        final int clippedDrawCount = clippingContext.clippedDrawableIndexList.size();
-        for (int clippedDrawableIndex = 0; clippedDrawableIndex < clippedDrawCount; clippedDrawableIndex++) {
+        int clippedDrawCount = 0;
+        switch (drawableObjectType) {
+            case DRAWABLE:
+            default:
+                clippedDrawCount = clippingContext.clippedDrawableIndexList.size();
+                break;
+            case OFFSCREEN: {
+                final int clippedOffscreenCount = clippingContext.clippedOffscreenIndexList.size();
+                // マスクを使用する描画オブジェクトの描画される矩形を求める。
+                for (int clippedOffscreenIndex = 0; clippedOffscreenIndex < clippedOffscreenCount; clippedOffscreenIndex++) {
+                    final int offscreenIndex = clippingContext.clippedOffscreenIndexList.get(clippedOffscreenIndex);
+                    collectOffscreenChildDrawableIndexList(model, offscreenIndex, clippedOffscreenChildDrawableIndexList);
+                }
+                clippedDrawCount = clippedOffscreenChildDrawableIndexList.size();
+                break;
+            }
+        }
+
+        for (int clippedObjectIndex = 0; clippedObjectIndex < clippedDrawCount; clippedObjectIndex++) {
+            int drawableVertexCount = 0;
+            float[] drawableVertices;
+
             // マスクを使用する描画オブジェクトの描画される矩形を求める。
-            final int drawableIndex = clippingContext.clippedDrawableIndexList.get(clippedDrawableIndex);
-
-            final int drawableVertexCount = model.getDrawableVertexCount(drawableIndex);
-            final float[] drawableVertices = model.getDrawableVertices(drawableIndex);
-
-            float minX = Float.MAX_VALUE;
-            float minY = Float.MAX_VALUE;
-            float maxX = -Float.MAX_VALUE;
-            float maxY = -Float.MAX_VALUE;
-
-            int loop = drawableVertexCount * VERTEX_STEP;
-            for (int pi = VERTEX_OFFSET; pi < loop; pi += VERTEX_STEP) {
-                float x = drawableVertices[pi];
-                float y = drawableVertices[pi + 1];
-                if (x < minX) minX = x;
-                if (x > maxX) maxX = x;
-                if (y < minY) minY = y;
-                if (y > maxY) maxY = y;
+            switch (drawableObjectType) {
+                case DRAWABLE:
+                default: {
+                    final int drawableIndex = clippingContext.clippedDrawableIndexList.get(clippedObjectIndex);
+                    drawableVertexCount = model.getDrawableVertexCount(drawableIndex);
+                    drawableVertices = model.getDrawableVertices(drawableIndex);
+                    break;
+                }
+                case OFFSCREEN: {
+                    final int drawableIndex = clippedOffscreenChildDrawableIndexList.get(clippedObjectIndex);
+                    drawableVertexCount = model.getDrawableVertexCount(drawableIndex);
+                    drawableVertices = model.getDrawableVertices(drawableIndex);
+                    break;
+                }
             }
-
-            if (minX == Float.MAX_VALUE) {
-                continue;   // 有効な点が1つも取れなかったのでスキップする
-            }
-
-            // 全体の矩形に反映
-            if (minX < clippedDrawTotalMinX) clippedDrawTotalMinX = minX;
-            if (maxX > clippedDrawTotalMaxX) clippedDrawTotalMaxX = maxX;
-            if (minY < clippedDrawTotalMinY) clippedDrawTotalMinY = minY;
-            if (maxY > clippedDrawTotalMaxY) clippedDrawTotalMaxY = maxY;
-        }
-
-        if (clippedDrawTotalMinX == Float.MAX_VALUE) {
-            clippingContext.isUsing = false;
-
-            csmRectF clippedDrawRect = clippingContext.allClippedDrawRect;
-            clippedDrawRect.setX(0.0f);
-            clippedDrawRect.setY(0.0f);
-            clippedDrawRect.setWidth(0.0f);
-            clippedDrawRect.setHeight(0.0f);
-        } else {
-            clippingContext.isUsing = true;
-            float w = clippedDrawTotalMaxX - clippedDrawTotalMinX;
-            float h = clippedDrawTotalMaxY - clippedDrawTotalMinY;
-
-            csmRectF clippedDrawRect = clippingContext.allClippedDrawRect;
-            clippedDrawRect.setX(clippedDrawTotalMinX);
-            clippedDrawRect.setY(clippedDrawTotalMinY);
-            clippedDrawRect.setWidth(w);
-            clippedDrawRect.setHeight(h);
-        }
-    }
-
-    /**
-     * マスクされるoffscreen描画オブジェクト群全体を囲む矩形（モデル座標系）を計算する。
-     *
-     * @param model           モデルのインスタンス
-     * @param clippingContext クリッピングマスクのコンテキスト
-     */
-    public void calcClippedOffscreenTotalBounds(CubismModel model, T_ClippingContext clippingContext) {
-        // 被クリッピングマスク（マスクされる描画オブジェクト）の全体の矩形
-        float clippedDrawTotalMinX = Float.MAX_VALUE;
-        float clippedDrawTotalMinY = Float.MAX_VALUE;
-        float clippedDrawTotalMaxX = -Float.MAX_VALUE;
-        float clippedDrawTotalMaxY = -Float.MAX_VALUE;
-
-        // このマスクが実際に必要か判定する
-        // このクリッピングを利用する「描画オブジェクト」がひとつでも使用可能であればマスクを生成する必要がある
-        final int clippedOffscreenCount = clippingContext.clippedOffscreenIndexList.size();
-
-        clippedOffscreenChildDrawableIndexList.clear();
-
-        for (int clippedOffscreenIndex = 0; clippedOffscreenIndex < clippedOffscreenCount; clippedOffscreenIndex++) {
-            // マスクを使用する描画オブジェクトの描画される矩形を求める
-            final int offscreenIndex = clippingContext.clippedOffscreenIndexList.get(clippedOffscreenIndex);
-            collectOffscreenChildDrawableIndexList(model, offscreenIndex, clippedOffscreenChildDrawableIndexList);
-        }
-
-        final int childDrawableCount = clippedOffscreenChildDrawableIndexList.size();
-        for (int childDrawableIndex = 0; childDrawableIndex < childDrawableCount; ++childDrawableIndex) {
-            final int drawableIndex = clippedOffscreenChildDrawableIndexList.get(childDrawableIndex);
-
-            final int drawableVertexCount = model.getDrawableVertexCount(drawableIndex);
-            final float[] drawableVertices = model.getDrawableVertices(drawableIndex);
 
             float minX = Float.MAX_VALUE;
             float minY = Float.MAX_VALUE;
@@ -781,8 +661,8 @@ public abstract class ACubismClippingManager<
      *
      * @return 画面描画に使用するクリッピングマスクのリスト
      */
-    public List<T_ClippingContext> getClippingContextListForDrawable() {
-        return clippingContextListForDrawable;
+    public List<T_ClippingContext> getClippingContextListForDraw() {
+        return clippingContextListForDraw;
     }
 
     /**
@@ -812,9 +692,9 @@ public abstract class ACubismClippingManager<
      */
     protected final List<T_ClippingContext> clippingContextListForMask = new ArrayList<>();
     /**
-     * Drawable用クリッピングコンテキストのリスト
+     * 描画用クリッピングコンテキストのリスト
      */
-    protected final List<T_ClippingContext> clippingContextListForDrawable = new ArrayList<>();
+    protected final List<T_ClippingContext> clippingContextListForDraw = new ArrayList<>();
 
     /**
      * Offscreen用クリッピングコンテキストのリスト

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/ICubismClippingManager.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/ICubismClippingManager.java
@@ -33,45 +33,40 @@ public interface ICubismClippingManager {
      * @param type               レンダラーの種類
      * @param model              モデルのインスタンス
      * @param maskBufferCount    バッファの生成数
+     * @param drawableObjectType 処理するオブジェクトタイプ
      */
-    void initializeForDrawable(
+    void initialize(
         CubismRenderer.RendererType type,
         CubismModel model,
-        int maskBufferCount
-    );
-
-    /**
-     * マネージャーの初期化処理
-     * クリッピングマスクを使うOffscreenオブジェクトの登録を行う。
-     *
-     * @param type            レンダラーの種類
-     * @param model           モデルのインスタンス
-     * @param maskBufferCount バッファの生成数
-     */
-    void initializeForOffscreen(
-        CubismRenderer.RendererType type,
-        CubismModel model,
-        int maskBufferCount
+        int maskBufferCount,
+        CubismRenderer.DrawableObjectType drawableObjectType
     );
 
     /**
      * 高精細マスク処理用の行列を計算する。
      *
-     * @param model         モデルのインスタンス
-     * @param isRightHanded 処理が右手系かどうか。右手系ならtrue
+     * @param model              モデルのインスタンス
+     * @param isRightHanded      処理が右手系かどうか。右手系ならtrue
+     * @param drawableObjectType 処理するオブジェクトタイプ
      */
-    void setupMatrixForDrawableHighPrecision(CubismModel model, boolean isRightHanded);
-
-    /**
-     * offscreenの高精細マスク処理用の行列を計算する。
-     *
-     * @param model         モデルのインスタンス
-     * @param isRightHanded 処理系が右手系かどうか。右手系ならtrue
-     * @param mvp           MVP行列
-     */
-    void setupMatrixForOffscreenHighPrecision(
+    void setupMatrixForHighPrecision(
         CubismModel model,
         boolean isRightHanded,
+        CubismRenderer.DrawableObjectType drawableObjectType
+    );
+
+    /**
+     * 高精細マスク処理用の行列を計算する。
+     *
+     * @param model              モデルのインスタンス
+     * @param isRightHanded      処理が右手系かどうか。右手系ならtrue
+     * @param drawableObjectType 処理するオブジェクトタイプ
+     * @param mvp                MVP行列
+     */
+    void setupMatrixForHighPrecision(
+        CubismModel model,
+        boolean isRightHanded,
+        CubismRenderer.DrawableObjectType drawableObjectType,
         final CubismMatrix44 mvp
     );
 

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismClippingManagerAndroid.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismClippingManagerAndroid.java
@@ -54,15 +54,7 @@ class CubismClippingManagerAndroid extends ACubismClippingManager<
             CubismClippingContextAndroid clipContext = clippingContextListForMask.get(i);
 
             // Calculate the rectangle that encloses the entire group of drawing objects that use this clip.
-            switch (drawableObjectType) {
-                case DRAWABLE:
-                default:
-                    calcClippedDrawableTotalBounds(model, clipContext);
-                    break;
-                case OFFSCREEN:
-                    calcClippedOffscreenTotalBounds(model, clipContext);
-                    break;
-            }
+            calcClippedTotalBounds(model, clipContext, drawableObjectType);
 
             if (clipContext.isUsing) {
                 // Count as in use.

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismRendererAndroid.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismRendererAndroid.java
@@ -102,10 +102,11 @@ public class CubismRendererAndroid extends CubismRenderer {
 
             // Initialize clipping mask and buffer preprocessing method
             drawableClippingManager = new CubismClippingManagerAndroid();
-            drawableClippingManager.initializeForDrawable(
+            drawableClippingManager.initialize(
                 RendererType.ANDROID,
                 model,
-                maskBufferCount
+                maskBufferCount,
+                CubismRenderer.DrawableObjectType.DRAWABLE
             );
 
             drawableMasks = new CubismRenderTargetAndroid[maskBufferCount];
@@ -121,10 +122,11 @@ public class CubismRendererAndroid extends CubismRenderer {
         if (model.isUsingMaskingForOffscreen()) {
             // クリッピングマスク・バッファ前処理方式を初期化
             offscreenClippingManager = new CubismClippingManagerAndroid();
-            offscreenClippingManager.initializeForOffscreen(
+            offscreenClippingManager.initialize(
                 RendererType.ANDROID,
                 model,
-                maskBufferCount
+                maskBufferCount,
+                CubismRenderer.DrawableObjectType.OFFSCREEN
             );
 
             offscreenMasks = new CubismRenderTargetAndroid[maskBufferCount];
@@ -281,10 +283,11 @@ public class CubismRendererAndroid extends CubismRenderer {
         drawableClippingManager = new CubismClippingManagerAndroid();
         drawableClippingManager.setClippingMaskBufferSize(width, height);
 
-        drawableClippingManager.initializeForDrawable(
+        drawableClippingManager.initialize(
             RendererType.ANDROID,
             getModel(),
-            renderTextureCount
+            renderTextureCount,
+            CubismRenderer.DrawableObjectType.DRAWABLE
         );
     }
 
@@ -308,10 +311,11 @@ public class CubismRendererAndroid extends CubismRenderer {
         offscreenClippingManager = new CubismClippingManagerAndroid();
         offscreenClippingManager.setClippingMaskBufferSize(width, height);
 
-        offscreenClippingManager.initializeForOffscreen(
+        offscreenClippingManager.initialize(
             RendererType.ANDROID,
             getModel(),
-            renderTextureCount
+            renderTextureCount,
+            CubismRenderer.DrawableObjectType.OFFSCREEN
         );
     }
 
@@ -536,7 +540,7 @@ public class CubismRendererAndroid extends CubismRenderer {
             }
 
             if (isUsingHighPrecisionMask()) {
-                drawableClippingManager.setupMatrixForDrawableHighPrecision(getModel(), false);
+                drawableClippingManager.setupMatrixForHighPrecision(getModel(), false, DrawableObjectType.DRAWABLE);
             } else {
                 drawableClippingManager.setupClippingContext(
                     getModel(),
@@ -561,9 +565,10 @@ public class CubismRendererAndroid extends CubismRenderer {
             }
 
             if (isUsingHighPrecisionMask()) {
-                offscreenClippingManager.setupMatrixForOffscreenHighPrecision(
+                offscreenClippingManager.setupMatrixForHighPrecision(
                     getModel(),
                     false,
+                    DrawableObjectType.OFFSCREEN,
                     getMvpMatrix()
                 );
             } else {
@@ -667,7 +672,7 @@ public class CubismRendererAndroid extends CubismRenderer {
 
         // クリッピングマスク
         CubismClippingContextAndroid clipContext = (drawableClippingManager != null)
-            ? drawableClippingManager.getClippingContextListForDrawable().get(drawableIndex)
+            ? drawableClippingManager.getClippingContextListForDraw().get(drawableIndex)
             : null;
 
         // マスクを描く必要がある

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismShaderAndroid.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismShaderAndroid.java
@@ -429,14 +429,12 @@ class CubismShaderAndroid {
 
         final boolean isMasked = renderer.getClippingContextBufferForOffscreen() != null;  // この描画オブジェクトはマスク対象か？
         final boolean isInvertedMask = model.getOffscreenInvertedMask(offscreenIndex);
-        final boolean isPremultipliedAlpha = renderer.isPremultipliedAlpha();
-
         final csmBlendMode blendMode = model.getOffscreenBlendModeType(offscreenIndex);
 
         final int shaderIndex = CubismShaderIndexCalculator.calculateShaderIndex(
             blendMode,
             determineMaskState(isMasked, isInvertedMask),
-            isPremultipliedAlpha
+            true    // オフスクリーン描画の場合は常にPremultipliedAlphaとして扱う。
         );
         CubismShaderSet shaderSet = shaderSets.get(shaderIndex);
 


### PR DESCRIPTION
### Fixed

* Fix clipping mask pre-processing by consolidating functions.
* Fix a bug where offscreen rendering results were not as expected when premultiplied alpha was disabled.
* Fix a bug where rendering results were not as expected when using Blend mode on semi-transparent objects.