### PR TITLE
Update to Cubism 5 SDK for Java R5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [5-r.5] - 2026-06-04
+
+### Added
+
+* Add a validation check for the current shader program before drawing polygon meshes.
+* Add `deleteRenderer()` method to `CubismUserModel` class.
+* Add `releaseInvalidShaderProgram()` method to `CubismShaderAndroid` class for releasing resources that have already been destroyed by the environment.
+* Add `CubismUpdateScheduler` class to control the order in which model parameter updates are executed.
+* Add `CubismLook` class for drag-driven parameter following with configurable parameter IDs.
+* Add `ACubismUpdater` abstract class and per-feature Updater subclasses (`CubismBreathUpdater`, `CubismExpressionUpdater`, `CubismEyeBlinkUpdater`, `CubismLipSyncUpdater`, `CubismLookUpdater`, `CubismPhysicsUpdater`, `CubismPoseUpdater`) used by `CubismUpdateScheduler` class.
+* Add `IParameterProvider` interface used to supply parameter values such as lip sync.
+* Add `IBooleanSupplier` functional interface used to read the latest value of a boolean field on every call.
+
+### Changed
+
+* Consolidate texture setup and vertex attribute setup code into dedicated methods in `CubismShaderAndroid` class.
+* Change shader generation from draw loop to `initialize()` in `CubismRendererAndroid` class.
+* Change the visibility of `CubismShaderAndroid` class from package-private to public.
+* Separate multiply color and screen color functions into a new class with renamed methods.
+* Change sampler settings in `CubismRenderTargetAndroid` and `CubismShaderAndroid` classes to align with the OpenGL ES 2.0 setting of SDK for Native.
+
+### Fixed
+
+* Unify remaining uses of `OffscreenSurface` in comments and parameter names to `RenderTarget`.
+* Fix an issue where `close()` method in `CubismRenderer` class unintentionally released model resources.
+* Fix `setupRenderer()` method in `CubismUserModel` class to delete the existing renderer before setting up a new one.
+* Fix `CubismShaderAndroid.deleteInstance()` to properly release shader programs by calling `glDeleteProgram()`.
+* Fix missing `@FunctionalInterface` annotation on functional interfaces.
+
+### Removed
+
+* Remove `lipSync`, `dragX`, and `dragY` fields from `CubismUserModel` class. Drag-driven parameter updates have been moved into the new `CubismLook` class, invoked by `CubismLookUpdater` class. Lip sync is handled by `CubismLipSyncUpdater` class together with `IParameterProvider` interface.
+
+
 ## [5-r.5-beta.1.1] - 2026-02-19
 
 ### Fixed
@@ -301,6 +335,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * New released!
 
 
+[5-r.5]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.5-beta.1.1...5-r.5
 [5-r.5-beta.1.1]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.5-beta.1...5-r.5-beta.1.1
 [5-r.5-beta.1]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.4.1...5-r.5-beta.1
 [5-r.4.1]: https://github.com/Live2D/CubismJavaFramework/compare/5-r.4...5-r.4.1

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/effect/CubismLook.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/effect/CubismLook.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+package com.live2d.sdk.cubism.framework.effect;
+
+import com.live2d.sdk.cubism.framework.id.CubismId;
+import com.live2d.sdk.cubism.framework.model.CubismModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Parameter following feature by target.
+ * Provides parameter following functionality for drag input.
+ */
+public class CubismLook {
+    /**
+     * Data attached to a look parameter.
+     */
+    public static class LookParameterData {
+        /**
+         * Default constructor.
+         */
+        public LookParameterData() {
+            this(null, 0.0f, 0.0f, 0.0f);
+        }
+
+        /**
+         * Constructor (factorX/Y/XY default to 0.0).
+         *
+         * @param parameterId ID of the parameter to attach
+         */
+        public LookParameterData(CubismId parameterId) {
+            this(parameterId, 0.0f, 0.0f, 0.0f);
+        }
+
+        /**
+         * Constructor (factorY/XY default to 0.0).
+         *
+         * @param parameterId ID of the parameter to attach
+         * @param factorX     coefficient for drag input along the X-axis
+         */
+        public LookParameterData(CubismId parameterId, final float factorX) {
+            this(parameterId, factorX, 0.0f, 0.0f);
+        }
+
+        /**
+         * Constructor (factorXY defaults to 0.0).
+         *
+         * @param parameterId ID of the parameter to attach
+         * @param factorX     coefficient for drag input along the X-axis
+         * @param factorY     coefficient for drag input along the Y-axis
+         */
+        public LookParameterData(CubismId parameterId, final float factorX, final float factorY) {
+            this(parameterId, factorX, factorY, 0.0f);
+        }
+
+        /**
+         * Constructor.
+         *
+         * @param parameterId ID of the parameter to attach
+         * @param factorX     coefficient for drag input along the X-axis
+         * @param factorY     coefficient for drag input along the Y-axis
+         * @param factorXY    coefficient for the combined X-Y (cross) drag input
+         */
+        public LookParameterData(CubismId parameterId, final float factorX, final float factorY, final float factorXY) {
+            this.parameterId = parameterId;
+            this.factorX = factorX;
+            this.factorY = factorY;
+            this.factorXY = factorXY;
+        }
+
+        /**
+         * ID of the parameter to attach.
+         */
+        public CubismId parameterId;
+        /**
+         * Coefficient for drag input along the X-axis.
+         */
+        public float factorX;
+        /**
+         * Coefficient for drag input along the Y-axis.
+         */
+        public float factorY;
+        /**
+         * Coefficient for the combined X-Y (cross) drag input.
+         */
+        public float factorXY;
+    }
+
+    /**
+     * Creates a {@code CubismLook} instance.
+     *
+     * @return a new {@code CubismLook} instance
+     */
+    public static CubismLook create() {
+        return new CubismLook();
+    }
+
+    /**
+     * Attaches the look parameters.
+     *
+     * @param lookParameters list of look parameters to attach
+     */
+    public void setParameters(final List<LookParameterData> lookParameters) {
+        this.lookParameters = lookParameters;
+    }
+
+    /**
+     * Returns the parameters attached to look.
+     *
+     * @return list of attached look parameters
+     */
+    public List<LookParameterData> getParameters() {
+        return lookParameters;
+    }
+
+    /**
+     * Updates model parameters based on the target drag input.
+     *
+     * <p><b>Note:</b> Call after creating an instance with {@link #create()} and binding parameters with {@link #setParameters(List)}.
+     *
+     * @param model the target model
+     * @param dragX X coordinate of the target
+     * @param dragY Y coordinate of the target
+     */
+    public void updateParameters(CubismModel model, final float dragX, final float dragY) {
+        final float dragXY = dragX * dragY;
+
+        for (int i = 0; i < lookParameters.size(); i++) {
+            final LookParameterData data = lookParameters.get(i);
+            model.addParameterValue(
+                data.parameterId,
+                data.factorX * dragX + data.factorY * dragY + data.factorXY * dragXY
+            );
+        }
+    }
+
+    private CubismLook() {}
+
+    private List<LookParameterData> lookParameters = new ArrayList<>();
+}

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismModel.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismModel.java
@@ -11,7 +11,6 @@ import com.live2d.sdk.cubism.core.*;
 import com.live2d.sdk.cubism.framework.CubismFramework;
 import com.live2d.sdk.cubism.framework.id.CubismId;
 import com.live2d.sdk.cubism.framework.math.CubismMath;
-import com.live2d.sdk.cubism.framework.rendering.CubismRenderer;
 import com.live2d.sdk.cubism.framework.rendering.CubismRenderer.CubismBlendMode;
 import com.live2d.sdk.cubism.framework.rendering.csmBlendMode;
 import com.live2d.sdk.cubism.framework.utils.CubismDebug;
@@ -43,55 +42,6 @@ public class CubismModel {
         CubismNoIndex(int index) {
             this.index = index;
         }
-    }
-
-    /**
-     * Structure for color information of drawing object.
-     */
-    public static class ColorData {
-        /**
-         * Constructor.
-         */
-        public ColorData() {
-            this.isOverridden = false;
-            this.color = new CubismRenderer.CubismTextureColor();
-        }
-
-        /**
-         * Constructor.
-         *
-         * @param isOverridden whether to be overridden
-         * @param color        texture color
-         */
-        public ColorData(boolean isOverridden, CubismRenderer.CubismTextureColor color) {
-            this.isOverridden = isOverridden;
-            this.color = new CubismRenderer.CubismTextureColor(color);
-        }
-
-        /**
-         * Copy constructor.
-         *
-         * @param other the ColorData object to copy from
-         */
-        public ColorData(ColorData other) {
-            this.isOverridden = other.isOverridden;
-            this.color = new CubismRenderer.CubismTextureColor(
-                other.color.r,
-                other.color.g,
-                other.color.b,
-                other.color.a
-            );
-        }
-
-        /**
-         * Whether to be overridden.
-         */
-        public boolean isOverridden;
-
-        /**
-         * Color.
-         */
-        public CubismRenderer.CubismTextureColor color;
     }
 
     /**
@@ -139,134 +89,6 @@ public class CubismModel {
     }
 
     /**
-     * (deprecated) Structure for color information of drawing object
-     *
-     * @deprecated This class is deprecated. Please use {@link ColorData} instead.
-     */
-    public static class DrawableColorData {
-        /**
-         * Constructor
-         */
-        public DrawableColorData() {
-            color = new CubismRenderer.CubismTextureColor();
-        }
-
-        /**
-         * Constructor
-         *
-         * @param isOverridden flag whether to be overridden
-         * @param color texture color
-         * @throws IllegalArgumentException if an argument is null
-         */
-        public DrawableColorData(boolean isOverridden, CubismRenderer.CubismTextureColor color) {
-            if (color == null) {
-                throw new IllegalArgumentException("color is null");
-            }
-            this.isOverridden = isOverridden;
-            this.color = color;
-        }
-
-        /**
-         * Copy constructor
-         *
-         * @param data DrawableColorData instance to be copied
-         */
-        public DrawableColorData(DrawableColorData data) {
-            this.isOverridden = data.isOverridden;
-            this.color = data.color;
-        }
-
-        /**
-         * flag whether to be overridden
-         */
-        public boolean isOverridden;
-        /**
-         * texture color
-         */
-        public CubismRenderer.CubismTextureColor color;
-    }
-
-    /**
-     * (deprecated) Structure to handle texture color in RGBA.
-     *
-     * @deprecated This class is deprecated. Please use {@link ColorData} instead.
-     */
-    public static class PartColorData {
-        /**
-         * コンストラクタ
-         */
-        public PartColorData() {
-            color = new CubismRenderer.CubismTextureColor();
-        }
-
-        /**
-         * コンストラクタ
-         *
-         * @param isOverridden SDKで設定した色情報でパーツの描画色を上書きするか。trueなら上書きする。
-         * @param color 色情報
-         */
-        public PartColorData(boolean isOverridden, CubismRenderer.CubismTextureColor color) {
-            if (color == null) {
-                throw new IllegalArgumentException("color is null");
-            }
-            this.isOverridden = isOverridden;
-            this.color = color;
-        }
-
-        /**
-         * コピーコンストラクタ
-         *
-         * @param data コピーするPartColorDataインスタンス
-         */
-        public PartColorData(PartColorData data) {
-            this.isOverridden = data.isOverridden;
-            this.color = data.color;
-        }
-
-        /**
-         * SDKで設定した色情報でパーツの描画色を上書きするか。trueなら上書きする。
-         */
-        public boolean isOverridden;
-
-        /**
-         * パーツの色情報
-         */
-        public CubismRenderer.CubismTextureColor color;
-    }
-
-    /**
-     * (deprecated) Structure to manage texture culling settings
-     *
-     * @deprecated This class is deprecated. Please use {@link CullingData} instead.
-     */
-    public static class DrawableCullingData {
-        /**
-         * コンストラクタ
-         */
-        DrawableCullingData() {}
-
-        /**
-         * コンストラクタ
-         *
-         * @param isOverridden モデルのカリング設定を上書きするかどうか
-         * @param isCulling カリングするかどうか
-         */
-        DrawableCullingData(boolean isOverridden, boolean isCulling) {
-            this.isOverridden = isOverridden;
-            this.isCulling = isCulling;
-        }
-
-        /**
-         * モデルのカリング設定を上書きするかどうか
-         */
-        public boolean isOverridden;
-        /**
-         * カリングするかどうか
-         */
-        public boolean isCulling;
-    }
-
-    /**
      * Class for managing the override of parameter repetition settings
      */
     public static class ParameterRepeatData {
@@ -298,133 +120,6 @@ public class CubismModel {
          * Override flag for settings
          */
         public boolean isParameterRepeated;
-    }
-
-    /**
-     * Information for part child draw objects.
-     */
-    public static class PartChildDrawObjects {
-        /**
-         * Constructor.
-         */
-        public PartChildDrawObjects() {
-            drawableIndices = new ArrayList<>();
-            offscreenIndices = new ArrayList<>();
-        }
-
-        /**
-         * Constructor.
-         *
-         * @param drawableIndices  collection of Drawable indices
-         * @param offscreenIndices collection of Offscreen indices
-         */
-        public PartChildDrawObjects(List<Integer> drawableIndices, List<Integer> offscreenIndices) {
-            this.drawableIndices = new ArrayList<>(drawableIndices);
-            this.offscreenIndices = new ArrayList<>(offscreenIndices);
-        }
-
-        /**
-         * Copy constructor.
-         *
-         * @param other the PartChildDrawObjects object to copy from
-         */
-        public PartChildDrawObjects(PartChildDrawObjects other) {
-            this.drawableIndices = new ArrayList<>(other.drawableIndices);
-            this.offscreenIndices = new ArrayList<>(other.offscreenIndices);
-        }
-
-        /**
-         * Collection of Drawable indices.
-         */
-        public List<Integer> drawableIndices;
-
-        /**
-         * Collection of Offscreen indices.
-         */
-        public List<Integer> offscreenIndices;
-    }
-
-    /**
-     * Information for a Cubism model object.
-     */
-    public static class CubismModelObjectInfo {
-        /**
-         * Type used in object information.
-         */
-        public enum ObjectType {
-            DRAWABLE(0),
-            PARTS(1);
-
-            public final int index;
-
-            ObjectType(int index) {
-                this.index = index;
-            }
-        }
-
-        /**
-         * Constructor.
-         *
-         * @param objectIndex index of the object
-         * @param type        type of the object (Drawable, Parts)
-         */
-        public CubismModelObjectInfo(int objectIndex, ObjectType type) {
-            this.objectIndex = objectIndex;
-            this.objectType = type;
-        }
-
-        /**
-         * Type of the object (Drawable, Parts).
-         */
-        public ObjectType objectType;
-
-        /**
-         * Index of the object.
-         */
-        public int objectIndex;
-    }
-
-    /**
-     * Information for a Cubism model part.
-     */
-    public static class CubismModelPartInfo {
-        /**
-         * Constructor.
-         */
-        public CubismModelPartInfo() {
-            objects = new ArrayList<>();
-            childDrawObjects = new PartChildDrawObjects();
-        }
-
-        /**
-         * Constructor
-         *
-         * @param objects          collection of CubismModelObjectInfo
-         * @param childDrawObjects information of part child draw objects
-         */
-        public CubismModelPartInfo(List<CubismModelObjectInfo> objects, PartChildDrawObjects childDrawObjects) {
-            this.objects = new ArrayList<>(objects);
-            this.childDrawObjects = new PartChildDrawObjects(childDrawObjects);
-        }
-
-        /**
-         * Collection of object information.
-         */
-        public List<CubismModelObjectInfo> objects;
-
-        /**
-         * Information of part child draw objects.
-         */
-        public PartChildDrawObjects childDrawObjects;
-
-        /**
-         * Returns the number of child objects.
-         *
-         * @return number of child objects
-         */
-        public int getChildObjectCount() {
-            return objects.size();
-        }
     }
 
     /**
@@ -1629,627 +1324,13 @@ public class CubismModel {
         }
     }
 
-    //========================================================
-    //  Color Functions.
-    //========================================================
-
     /**
-     * Get the multiply color from the list.
+     * Returns the multiply and screen color settings.
      *
-     * @param drawableIndex index of the drawable
-     * @return the multiply color
+     * @return multiply and screen color settings
      */
-    public CubismRenderer.CubismTextureColor getMultiplyColor(int drawableIndex) {
-        if (getOverrideFlagForModelMultiplyColors() || getOverrideFlagForDrawableMultiplyColors(drawableIndex)) {
-            return userDrawableMultiplyColors.get(drawableIndex).color;
-        }
-
-        float[] color = getDrawableMultiplyColor(drawableIndex);
-        multiplyColor.r = color[0];
-        multiplyColor.g = color[1];
-        multiplyColor.b = color[2];
-        multiplyColor.a = color[3];
-
-        return multiplyColor;
-    }
-
-    // This is only used by 'getMultiplyColor' method.
-    // Avoid creating a new CubismTextureColor instance in getter method.
-    private final CubismRenderer.CubismTextureColor multiplyColor = new CubismRenderer.CubismTextureColor();
-
-    /**
-     * Get the screen color from the list.
-     *
-     * @param drawableIndex index of the drawable
-     * @return the screen color
-     */
-    public CubismRenderer.CubismTextureColor getScreenColor(int drawableIndex) {
-        if (getOverrideFlagForModelScreenColors() || getOverrideFlagForDrawableScreenColors(drawableIndex)) {
-            return userDrawableScreenColors.get(drawableIndex).color;
-        }
-
-        float[] color = getDrawableScreenColor(drawableIndex);
-        screenColor.r = color[0];
-        screenColor.g = color[1];
-        screenColor.b = color[2];
-        screenColor.a = color[3];
-
-        return screenColor;
-    }
-
-    // This is only used by 'getScreenColor' method.
-    // Avoid creating a new CubismTextureColor instance in getter method.
-    private final CubismRenderer.CubismTextureColor screenColor = new CubismRenderer.CubismTextureColor();
-
-    /**
-     * Set the multiply color of Drawable.
-     *
-     * @param drawableIndex index of the drawable
-     * @param color the multiply color instance
-     */
-    public void setMultiplyColor(int drawableIndex, CubismRenderer.CubismTextureColor color) {
-        setMultiplyColor(drawableIndex, color.r, color.g, color.b, color.a);
-    }
-
-    /**
-     * Set the multiply color of Drawable.
-     *
-     * @param drawableIndex index of the drawable
-     * @param r red value
-     * @param g green value
-     * @param b blue value
-     * @param a alpha value
-     */
-    public void setMultiplyColor(int drawableIndex, float r, float g, float b, float a) {
-        userDrawableMultiplyColors.get(drawableIndex).color.r = r;
-        userDrawableMultiplyColors.get(drawableIndex).color.g = g;
-        userDrawableMultiplyColors.get(drawableIndex).color.b = b;
-        userDrawableMultiplyColors.get(drawableIndex).color.a = a;
-    }
-
-    /**
-     * Partの乗算色を取得する。
-     *
-     * @param partIndex 取得したいPartのインデックス
-     * @return Partの乗算色
-     */
-    public CubismRenderer.CubismTextureColor getPartMultiplyColor(int partIndex) {
-        return userPartMultiplyColors.get(partIndex).color;
-    }
-
-    /**
-     * Partのスクリーン色を取得する。
-     *
-     * @param partIndex 取得したいPartのインデックス
-     * @return Partのスクリーン色
-     */
-    public CubismRenderer.CubismTextureColor getPartScreenColor(int partIndex) {
-        return userPartScreenColors.get(partIndex).color;
-    }
-
-    /**
-     * Partの乗算色を設定する。
-     *
-     * @param partIndex 乗算色を設定するパーツのインデックス
-     * @param color 乗算色
-     */
-    public void setPartMultiplyColor(int partIndex, CubismRenderer.CubismTextureColor color) {
-        setPartColor(partIndex, color.r, color.g, color.b, color.a, userPartMultiplyColors, userDrawableMultiplyColors);
-    }
-
-    /**
-     * Partの乗算色を設定する。
-     *
-     * @param partIndex 乗算色を設定するパーツのインデックス
-     * @param r 赤
-     * @param g 緑
-     * @param b 青
-     * @param a アルファ
-     */
-    public void setPartMultiplyColor(int partIndex, float r, float g, float b, float a) {
-        setPartColor(partIndex, r, g, b, a, userPartMultiplyColors, userDrawableMultiplyColors);
-    }
-
-    /**
-     * Set the screen color of Drawable.
-     *
-     * @param drawableIndex index of the drawable
-     * @param color the screen color instance
-     */
-    public void setScreenColor(int drawableIndex, CubismRenderer.CubismTextureColor color) {
-        setScreenColor(drawableIndex, color.r, color.g, color.b, color.a);
-    }
-
-    /**
-     * Set the screen color of Drawable.
-     *
-     * @param drawableIndex index of the drawable
-     * @param r red value
-     * @param g green value
-     * @param b blue value
-     * @param a alpha value
-     */
-    public void setScreenColor(int drawableIndex, float r, float g, float b, float a) {
-        userDrawableScreenColors.get(drawableIndex).color.r = r;
-        userDrawableScreenColors.get(drawableIndex).color.g = g;
-        userDrawableScreenColors.get(drawableIndex).color.b = b;
-        userDrawableScreenColors.get(drawableIndex).color.a = a;
-    }
-
-    /**
-     * Partのスクリーン色を設定する。
-     *
-     * @param partIndex スクリーン色を設定するパーツのインデックス
-     * @param color スクリーン色
-     */
-    public void setPartScreenColor(int partIndex, CubismRenderer.CubismTextureColor color) {
-        setPartScreenColor(partIndex, color.r, color.g, color.b, color.a);
-    }
-
-    /**
-     * Partのスクリーン色を設定する。
-     *
-     * @param partIndex スクリーン色を設定するパーツのインデックス
-     * @param r 赤
-     * @param g 緑
-     * @param b 青
-     * @param a アルファ
-     */
-    public void setPartScreenColor(int partIndex, float r, float g, float b, float a) {
-        setPartColor(partIndex, r, g, b, a, userPartScreenColors, userDrawableScreenColors);
-    }
-
-    /**
-     * Returns the multiply color from the list of offscreen.
-     * <p>
-     * NOTE: This method returns a cached instance for optimization purposes.
-     *
-     * @param offscreenIndex offscreen index
-     * @return multiply color (CubismTextureColor)
-     */
-    public CubismRenderer.CubismTextureColor getMultiplyColorOffscreen(int offscreenIndex) {
-        if (getOverrideFlagForModelMultiplyColors() || getOverrideFlagForOffscreenMultiplyColors(offscreenIndex)) {
-            return userOffscreenMultiplyColors.get(offscreenIndex).color;
-        }
-
-        final float[] tmpColor = getOffscreenMultiplyColor(offscreenIndex);
-
-        // インスタンス生成を避けるため、キャッシュリストからインスタンスを取得して値を更新
-        CubismRenderer.CubismTextureColor color = offscreenMultiplyColors.get(offscreenIndex);
-        color.r = tmpColor[0];
-        color.g = tmpColor[1];
-        color.b = tmpColor[2];
-        color.a = tmpColor[3];
-
-        return color;
-    }
-
-    /**
-     * Returns the screen color from the list of offscreen.
-     * <p>
-     * NOTE: This method returns a cached instance for optimization purposes.
-     *
-     * @param offscreenIndex offscreen index
-     * @return screen color (CubismTextureColor)
-     */
-    public CubismRenderer.CubismTextureColor getScreenColorOffscreen(int offscreenIndex) {
-        if (getOverrideFlagForModelScreenColors() || getOverrideFlagForOffscreenScreenColors(offscreenIndex)) {
-            return userOffscreenScreenColors.get(offscreenIndex).color;
-        }
-
-        final float[] tmpColor = getOffscreenScreenColor(offscreenIndex);
-
-        // インスタンス生成を避けるため、キャッシュリストからインスタンスを取得して値を更新
-        CubismRenderer.CubismTextureColor color = offscreenScreenColors.get(offscreenIndex);
-        color.r = tmpColor[0];
-        color.g = tmpColor[1];
-        color.b = tmpColor[2];
-        color.a = tmpColor[3];
-
-        return color;
-    }
-
-    /**
-     * Sets the multiply color of the offscreen.
-     *
-     * @param offscreenIndex offscreen index
-     * @param color          multiply color to be set (CubismTextureColor)
-     */
-    public void setMultiplyColorOffscreen(int offscreenIndex, final CubismRenderer.CubismTextureColor color) {
-        setMultiplyColorOffscreen(offscreenIndex, color.r, color.g, color.b, color.a);
-    }
-
-    /**
-     * Sets the multiply color of the offscreen.
-     *
-     * @param offscreenIndex offscreen index
-     * @param r              red value of the multiply color to be set
-     * @param g              green value of the multiply color to be set
-     * @param b              blue value of the multiply color to be set
-     * @param a              alpha value of the multiply color to be set
-     */
-    public void setMultiplyColorOffscreen(
-        int offscreenIndex,
-        float r,
-        float g,
-        float b,
-        float a
-    ) {
-        userOffscreenMultiplyColors.get(offscreenIndex).color.r = r;
-        userOffscreenMultiplyColors.get(offscreenIndex).color.g = g;
-        userOffscreenMultiplyColors.get(offscreenIndex).color.b = b;
-        userOffscreenMultiplyColors.get(offscreenIndex).color.a = a;
-    }
-
-    /**
-     * Sets the multiply color of the offscreen.
-     *
-     * @param offscreenIndex offscreen index
-     * @param r              red value of the multiply color to be set
-     * @param g              green value of the multiply color to be set
-     * @param b              blue value of the multiply color to be set
-     */
-    public void setMultiplyColorOffscreen(
-        int offscreenIndex,
-        float r,
-        float g,
-        float b
-    ) {
-        setMultiplyColorOffscreen(offscreenIndex, r, g, b, 1.0f);
-    }
-
-    /**
-     * Sets the screen color of the offscreen.
-     *
-     * @param offscreenIndex offscreen index
-     * @param color          screen color to be set (CubismTextureColor)
-     */
-    public void setScreenColorOffscreen(int offscreenIndex, final CubismRenderer.CubismTextureColor color) {
-        setScreenColorOffscreen(offscreenIndex, color.r, color.g, color.b, color.a);
-    }
-
-    /**
-     * Sets the screen color of the offscreen.
-     *
-     * @param offscreenIndex offscreen index
-     * @param r              red value of the screen color to be set
-     * @param g              green value of the screen color to be set
-     * @param b              blue value of the screen color to be set
-     * @param a              alpha value of the screen color to be set
-     */
-    public void setScreenColorOffscreen(
-        int offscreenIndex,
-        float r,
-        float g,
-        float b,
-        float a
-    ) {
-        userOffscreenScreenColors.get(offscreenIndex).color.r = r;
-        userOffscreenScreenColors.get(offscreenIndex).color.g = g;
-        userOffscreenScreenColors.get(offscreenIndex).color.b = b;
-        userOffscreenScreenColors.get(offscreenIndex).color.a = a;
-    }
-
-    /**
-     * Sets the screen color of the offscreen.
-     *
-     * @param offscreenIndex offscreen index
-     * @param r              red value of the screen color to be set
-     * @param g              green value of the screen color to be set
-     * @param b              blue value of the screen color to be set
-     */
-    public void setScreenColorOffscreen(
-        int offscreenIndex,
-        float r,
-        float g,
-        float b
-    ) {
-        setScreenColorOffscreen(offscreenIndex, r, g, b, 1.0f);
-    }
-
-
-    /**
-     * Whether to override the entire model multiply color from the SDK.
-     *
-     * @deprecated This function is deprecated due to a naming change, use getOverrideFlagForModelMultiplyColors() instead.
-     *
-     * @return If the color information on the SDK is used, return true. If the color information of the model is used, return false.
-     */
-    public boolean getOverwriteFlagForModelMultiplyColors() {
-        CubismDebug.cubismLogWarning("getOverwriteFlagForModelMultiplyColors() is a deprecated function. Please use getOverrideFlagForModelMultiplyColors().");
-        return getOverrideFlagForModelMultiplyColors();
-    }
-
-    /**
-     * Whether to override the entire model multiply color from the SDK.
-     *
-     * @return If the color information on the SDK is used, return true. If the color information of the model is used, return false.
-     */
-    public boolean getOverrideFlagForModelMultiplyColors() {
-        return isOverriddenModelMultiplyColors;
-    }
-
-    /**
-     * Whether to override the entire model screen color from the SDK.
-     *
-     * @deprecated This function is deprecated due to a naming change, use getOverrideFlagForModelScreenColors() instead.
-     *
-     * @return If the color information on the SDK is used, return true. If the color information of the model is used, return false.
-     */
-    public boolean getOverwriteFlagForModelScreenColors() {
-        CubismDebug.cubismLogWarning("getOverwriteFlagForModelScreenColors() is a deprecated function. Please use getOverrideFlagForModelScreenColors().");
-        return getOverrideFlagForModelScreenColors();
-    }
-
-    /**
-     * Whether to override the entire model screen color from the SDK.
-     *
-     * @return If the color information on the SDK is used, return true. If the color information of the model is used, return false.
-     */
-    public boolean getOverrideFlagForModelScreenColors() {
-        return isOverriddenModelScreenColors;
-    }
-
-    /**
-     * Set the flag whether to override the entire model multiply color from the SDK.
-     *
-     * @deprecated This function is deprecated due to a naming change, use setOverrideFlagForModelMultiplyColors(boolean value) instead.
-     *
-     * @param value If the color information on the SDK is used, this value is true. If the color information of the model is used, this is false.
-     */
-    public void setOverwriteFlagForModelMultiplyColors(boolean value) {
-        CubismDebug.cubismLogWarning("setOverwriteFlagForModelMultiplyColors(boolean value) is a deprecated function. Please use setOverrideFlagForModelMultiplyColors(boolean value).");
-        setOverrideFlagForModelMultiplyColors(value);
-    }
-
-    /**
-     * Set the flag whether to override the entire model multiply color from the SDK.
-     *
-     * @param value If the color information on the SDK is used, this value is true. If the color information of the model is used, this is false.
-     */
-    public void setOverrideFlagForModelMultiplyColors(boolean value) {
-        isOverriddenModelMultiplyColors = value;
-    }
-
-    /**
-     * Set the flag whether to override the entire model screen color from the SDK.
-     *
-     * @deprecated This function is deprecated due to a naming change, use setOverrideFlagForModelScreenColors(boolean value) instead.
-     *
-     * @param value If the color information on the SDK is used, this value is true. If the color information of the model is used, this is false.
-     */
-    public void setOverwriteFlagForModelScreenColors(boolean value) {
-        CubismDebug.cubismLogWarning("setOverwriteFlagForModelScreenColors(boolean value) is a deprecated function. Please use setOverrideFlagForModelScreenColors(boolean value).");
-        setOverrideFlagForModelScreenColors(value);
-    }
-
-    /**
-     * Set the flag whether to override the entire model screen color from the SDK.
-     *
-     * @param value If the color information on the SDK is used, this value is true. If the color information of the model is used, this is false.
-     */
-    public void setOverrideFlagForModelScreenColors(boolean value) {
-        isOverriddenModelScreenColors = value;
-    }
-
-    /**
-     * Whether to override the drawable multiply color from the SDK.
-     *
-     * @deprecated This function is deprecated due to a naming change, use getOverrideFlagForDrawableMultiplyColors(int drawableIndex) instead.
-     *
-     * @return If the color information on the SDK is used, return true. If the color information of the model is used, return false.
-     */
-    public boolean getOverwriteFlagForDrawableMultiplyColors(int drawableIndex) {
-        CubismDebug.cubismLogWarning("getOverwriteFlagForDrawableMultiplyColors(int drawableIndex) is a deprecated function. Please use getOverrideFlagForDrawableMultiplyColors(int drawableIndex).");
-        return getOverrideFlagForDrawableMultiplyColors(drawableIndex);
-    }
-
-    /**
-     * Whether to override the drawable multiply color from the SDK.
-     *
-     * @return If the color information on the SDK is used, return true. If the color information of the model is used, return false.
-     */
-    public boolean getOverrideFlagForDrawableMultiplyColors(int drawableIndex) {
-        return userDrawableMultiplyColors.get(drawableIndex).isOverridden;
-    }
-
-    /**
-     * Whether to override the drawable screen color from the SDK.
-     *
-     * @deprecated This function is deprecated due to a naming change, use getOverrideFlagForDrawableScreenColors(int drawableIndex) instead.
-     *
-     * @return If the color information on the SDK is used, return true. If the color information of the model is used, return false.
-     */
-    public boolean getOverwriteFlagForDrawableScreenColors(int drawableIndex) {
-        CubismDebug.cubismLogWarning("getOverwriteFlagForDrawableScreenColors(int drawableIndex) is a deprecated function. Please use getOverrideFlagForDrawableScreenColors(int drawableIndex).");
-        return getOverrideFlagForDrawableScreenColors(drawableIndex);
-    }
-
-    /**
-     * Whether to override the drawable screen color from the SDK.
-     *
-     * @return If the color information on the SDK is used, return true. If the color information of the model is used, return false.
-     */
-    public boolean getOverrideFlagForDrawableScreenColors(int drawableIndex) {
-        return userDrawableScreenColors.get(drawableIndex).isOverridden;
-    }
-
-    /**
-     * SDKからPartの乗算色を上書きするかどうかのフラグを取得する。
-     *
-     * @deprecated This function is deprecated due to a naming change, use getOverrideColorForPartMultiplyColors(int partIndex) instead.
-     *
-     * @param partIndex 上書きするPartのインデックス
-     * @return SDKからPartの乗算色を上書きするか。上書きするならtrue。
-     */
-    public boolean getOverwriteColorForPartMultiplyColors(int partIndex) {
-        CubismDebug.cubismLogWarning("getOverwriteColorForPartMultiplyColors(int partIndex) is a deprecated function. Please use getOverrideColorForPartMultiplyColors(int partIndex).");
-        return getOverrideColorForPartMultiplyColors(partIndex);
-    }
-
-    /**
-     * SDKからPartの乗算色を上書きするかどうかのフラグを取得する。
-     *
-     * @param partIndex 上書きするPartのインデックス
-     * @return SDKからPartの乗算色を上書きするか。上書きするならtrue。
-     */
-    public boolean getOverrideColorForPartMultiplyColors(int partIndex) {
-        return userPartMultiplyColors.get(partIndex).isOverridden;
-    }
-
-    /**
-     * SDKからPartのスクリーン色を上書きするかどうかのフラグを取得する。
-     *
-     * @deprecated This function is deprecated due to a naming change, use  getOverrideColorForPartScreenColors(int partIndex) instead.
-     *
-     * @param partIndex 上書きするPartのインデックス
-     * @return SDKからPartのスクリーン色を上書きするか。上書きするならtrue。
-     */
-    public boolean getOverwriteColorForPartScreenColors(int partIndex) {
-        CubismDebug.cubismLogWarning("getOverwriteColorForPartScreenColors(int partIndex) is a deprecated function. Please use getOverrideColorForPartScreenColors(int partIndex).");
-        return getOverrideColorForPartScreenColors(partIndex);
-    }
-
-    /**
-     * SDKからPartのスクリーン色を上書きするかどうかのフラグを取得する。
-     *
-     * @param partIndex 上書きするPartのインデックス
-     * @return SDKからPartのスクリーン色を上書きするか。上書きするならtrue。
-     */
-    public boolean getOverrideColorForPartScreenColors(int partIndex) {
-        return userPartScreenColors.get(partIndex).isOverridden;
-    }
-
-    /**
-     * Set the flag whether to override the drawable multiply color from the SDK.
-     *
-     * @deprecated This function is deprecated due to a naming change, use setOverrideFlagForDrawableMultiplyColors(int drawableIndex, boolean value) instead.
-     *
-     * @param value If the color information on the SDK is used, this value is true. If the color information of the model is used, this is false.
-     */
-    public void setOverwriteFlagForDrawableMultiplyColors(int drawableIndex, boolean value) {
-        CubismDebug.cubismLogWarning("setOverwriteFlagForDrawableMultiplyColors(int drawableIndex, boolean value) is a deprecated function. Please use setOverrideFlagForDrawableMultiplyColors(int drawableIndex, boolean value).");
-        setOverrideFlagForDrawableMultiplyColors(drawableIndex, value);
-    }
-
-    /**
-     * Set the flag whether to override the drawable multiply color from the SDK.
-     *
-     * @param value If the color information on the SDK is used, this value is true. If the color information of the model is used, this is false.
-     */
-    public void setOverrideFlagForDrawableMultiplyColors(int drawableIndex, boolean value) {
-        userDrawableMultiplyColors.get(drawableIndex).isOverridden = value;
-    }
-
-    /**
-     * Set the flag whether to override the drawable screen color from the SDK.
-     *
-     * @deprecated This function is deprecated due to a naming change, use setOverrideFlagForDrawableScreenColors(int drawableIndex, boolean value) instead.
-     *
-     * @param value If the color information on the SDK is used, this value is true. If the color information of the model is used, this is false.
-     */
-    public void setOverwriteFlagForDrawableScreenColors(int drawableIndex, boolean value) {
-        CubismDebug.cubismLogWarning("setOverwriteFlagForDrawableScreenColors(int drawableIndex, boolean value) is a deprecated function. Please use setOverrideFlagForDrawableScreenColors(int drawableIndex, boolean value).");
-        setOverrideFlagForDrawableScreenColors(drawableIndex, value);
-    }
-
-    /**
-     * Set the flag whether to override the drawable screen color from the SDK.
-     *
-     * @param value If the color information on the SDK is used, this value is true. If the color information of the model is used, this is false.
-     */
-    public void setOverrideFlagForDrawableScreenColors(int drawableIndex, boolean value) {
-        userDrawableScreenColors.get(drawableIndex).isOverridden = value;
-    }
-
-    /**
-     * SDKからPartの乗算色を上書きするかどうかのフラグを設定する。
-     *
-     * @deprecated This function is deprecated due to a naming change, use setOverrideColorForPartMultiplyColors(int partIndex, boolean value) instead.
-     *
-     * @param partIndex 上書きするPartのインデックス
-     * @param value SDKからPartの乗算色を上書きするかどうか。trueなら上書きする。
-     */
-    public void setOverwriteColorForPartMultiplyColors(int partIndex, boolean value) {
-        CubismDebug.cubismLogWarning("setOverwriteColorForPartMultiplyColors(int partIndex, boolean value) is a deprecated function. Please use setOverrideColorForPartMultiplyColors(int partIndex, boolean value).");
-        setOverrideColorForPartMultiplyColors(partIndex, value);
-    }
-
-    /**
-     * SDKからPartの乗算色を上書きするかどうかのフラグを設定する。
-     *
-     * @param partIndex 上書きするPartのインデックス
-     * @param value SDKからPartの乗算色を上書きするかどうか。trueなら上書きする。
-     */
-    public void setOverrideColorForPartMultiplyColors(int partIndex, boolean value) {
-        userPartMultiplyColors.get(partIndex).isOverridden = value;
-        setOverrideColorsForPartColors(partIndex, value, userPartMultiplyColors, userDrawableMultiplyColors);
-    }
-
-    /**
-     * SDKからPartのスクリーン色を上書きするかどうかのフラグを設定する。
-     *
-     * @deprecated This function is deprecated due to a naming change, use setOverrideColorForPartScreenColors(int partIndex, boolean value) instead.
-     *
-     * @param partIndex 上書きするPartのインデックス
-     * @param value SDKからPartのスクリーン色を上書きするかどうか。trueなら上書きする。
-     */
-    public void setOverwriteColorForPartScreenColors(int partIndex, boolean value) {
-        CubismDebug.cubismLogWarning("setOverwriteColorForPartScreenColors(int partIndex, boolean value) is a deprecated function. Please use setOverrideColorForPartScreenColors(int partIndex, boolean value).");
-        setOverrideColorForPartScreenColors(partIndex, value);
-    }
-
-    /**
-     * SDKからPartのスクリーン色を上書きするかどうかのフラグを設定する。
-     *
-     * @param partIndex 上書きするPartのインデックス
-     * @param value SDKからPartのスクリーン色を上書きするかどうか。trueなら上書きする。
-     */
-    public void setOverrideColorForPartScreenColors(int partIndex, boolean value) {
-        userPartScreenColors.get(partIndex).isOverridden = value;
-        setOverrideColorsForPartColors(partIndex, value, userPartScreenColors, userDrawableScreenColors);
-    }
-
-    /**
-     * Checks whether the offscreen multiply color is overridden by the SDK.
-     *
-     * @param offscreenIndex offscreen index
-     * @return true if the color information from the SDK is used; otherwise false.
-     */
-    public boolean getOverrideFlagForOffscreenMultiplyColors(int offscreenIndex) {
-        return userOffscreenMultiplyColors.get(offscreenIndex).isOverridden;
-    }
-
-    /**
-     * Checks whether the offscreen screen color is overridden by the SDK.
-     *
-     * @param offscreenIndex offscreen index
-     * @return true if the color information from the SDK is used; otherwise false.
-     */
-    public boolean getOverrideFlagForOffscreenScreenColors(int offscreenIndex) {
-        return userOffscreenScreenColors.get(offscreenIndex).isOverridden;
-    }
-
-    /**
-     * Sets whether the offscreen multiply color is overridden by the SDK.
-     * Use true to use the color information from the SDK, or false to use the color information from the model.
-     *
-     * @param offscreenIndex offscreen index
-     * @param value          offscreen True enable override, false to disable
-     */
-    public void setOverrideFlagForOffscreenMultiplyColors(int offscreenIndex, boolean value) {
-        userOffscreenMultiplyColors.get(offscreenIndex).isOverridden = value;
-    }
-
-    /**
-     * Sets whether the offscreen screen color is overridden by the SDK.
-     * Use true to use the color information from the SDK, or false to use the color information from the model.
-     *
-     * @param offscreenIndex offscreen index
-     * @param value          offscreen True enable override, false to disable
-     */
-    public void setOverrideFlagForOffscreenScreenColors(int offscreenIndex, boolean value) {
-        userOffscreenScreenColors.get(offscreenIndex).isOverridden = value;
+    public CubismModelMultiplyAndScreenColor getOverrideMultiplyAndScreenColor() {
+        return overrideMultiplyAndScreenColor;
     }
 
     /**
@@ -2268,10 +1349,10 @@ public class CubismModel {
     }
 
     /**
-     * Drawableのカリング情報を設定する
+     * Sets the culling information of the drawable.
      *
-     * @param drawableIndex drawableのインデックス
-     * @param isCulling カリングするかどうか
+     * @param drawableIndex drawable index
+     * @param isCulling true to enable culling, false to disable
      */
     public void setDrawableCulling(int drawableIndex, boolean isCulling) {
         userDrawableCullings.get(drawableIndex).isCulling = isCulling;
@@ -2353,11 +1434,10 @@ public class CubismModel {
     }
 
     /**
-     * SDKからモデル全体のカリング設定を上書きするか
+     * Checks whether the culling settings for the model are overridden by the SDK.
      *
+     * @return true to use the SDK's culling settings, false to use the model's culling settings
      * @deprecated This function is deprecated due to a naming change, use getOverrideFlagForModelCullings() instead.
-     *
-     * @return trueならSDK上のカリング設定を使用し、falseならモデルのカリング設定を使用する
      */
     public boolean getOverwriteFlagForModelCullings() {
         CubismDebug.cubismLogWarning("getOverwriteFlagForModelCullings() is a deprecated function. Please use getOverrideFlagForModelCullings().");
@@ -2365,20 +1445,19 @@ public class CubismModel {
     }
 
     /**
-     * SDKからモデル全体のカリング設定を上書きするか
+     * Checks whether the culling settings for the model are overridden by the SDK.
      *
-     * @return trueならSDK上のカリング設定を使用し、falseならモデルのカリング設定を使用する
+     * @return true to use the SDK's culling settings, false to use the model's culling settings
      */
     public boolean getOverrideFlagForModelCullings() {
         return isOverriddenCullings;
     }
 
     /**
-     * SDK上からモデル全体のカリング設定を上書きするかをセットする
+     * Sets whether the culling settings for the model are overridden by the SDK.
      *
+     * @param value true to use the SDK's culling settings, false to use the model's culling settings
      * @deprecated This function is deprecated due to a naming change, use setOverrideFlagForModelCullings(boolean value) instead.
-     *
-     * @param value SDK上のカリング設定を使うならtrue, モデルのカリング設定を使うならfalse
      */
     public void setOverwriteFlagForModelCullings(boolean value) {
         CubismDebug.cubismLogWarning("setOverwriteFlagForModelCullings(boolean value) is a deprecated function. Please use setOverrideFlagForModelCullings(boolean value).");
@@ -2386,21 +1465,20 @@ public class CubismModel {
     }
 
     /**
-     * SDK上からモデル全体のカリング設定を上書きするかをセットする
+     * Sets whether the culling settings for the model are overridden by the SDK.
      *
-     * @param value SDK上のカリング設定を使うならtrue, モデルのカリング設定を使うならfalse
+     * @param value true to use the SDK's culling settings, false to use the model's culling settings
      */
     public void setOverrideFlagForModelCullings(boolean value) {
         isOverriddenCullings = value;
     }
 
     /**
-     * SDKからdrawableのカリング設定を上書きするか
+     * Checks whether the culling settings for the drawable are overridden by the SDK.
      *
+     * @param drawableIndex drawable index
+     * @return true to use the SDK's culling settings, false to use the model's culling settings
      * @deprecated This function is deprecated due to a naming change, use getOverrideFlagForDrawableCullings(int drawableIndex) instead.
-     *
-     * @param drawableIndex drawableのインデックス
-     * @return trueならSDK上のカリング設定を使用し、falseならモデルのカリング設定を使用する
      */
     public boolean getOverwriteFlagForDrawableCullings(int drawableIndex) {
         CubismDebug.cubismLogWarning("getOverwriteFlagForDrawableCullings(int drawableIndex) is a deprecated function. Please use getOverrideFlagForDrawableCullings(int drawableIndex).");
@@ -2408,22 +1486,21 @@ public class CubismModel {
     }
 
     /**
-     * SDKからdrawableのカリング設定を上書きするか
+     * Checks whether the culling settings for the drawable are overridden by the SDK.
      *
-     * @param drawableIndex drawableのインデックス
-     * @return trueならSDK上のカリング設定を使用し、falseならモデルのカリング設定を使用する
+     * @param drawableIndex drawable index
+     * @return true to use the SDK's culling settings, false to use the model's culling settings
      */
     public boolean getOverrideFlagForDrawableCullings(int drawableIndex) {
         return userDrawableCullings.get(drawableIndex).isOverridden;
     }
 
     /**
-     * SDKからdrawableのカリング設定を上書きするかをセットする
+     * Sets whether the culling settings for the drawable are overridden by the SDK.
      *
+     * @param drawableIndex drawable index
+     * @param value         true to use the SDK's culling settings, false to use the model's culling settings
      * @deprecated This function is deprecated due to a naming change, use setOverrideFlagForDrawableCullings(int drawableIndex, boolean value) instead.
-     *
-     * @param drawableIndex drawableのインデックス
-     * @param value SDK上のカリング設定を使うならtrue, モデルのカリング設定を使うならfalse
      */
     public void setOverwriteFlagForDrawableCullings(int drawableIndex, boolean value) {
         CubismDebug.cubismLogWarning("setOverwriteFlagForDrawableCullings(int drawableIndex, boolean value) is a deprecated function. Please use setOverrideFlagForDrawableCullings(int drawableIndex, boolean value).");
@@ -2431,10 +1508,10 @@ public class CubismModel {
     }
 
     /**
-     * SDKからdrawableのカリング設定を上書きするかをセットする
+     * Sets whether the culling settings for the drawable are overridden by the SDK.
      *
-     * @param drawableIndex drawableのインデックス
-     * @param value SDK上のカリング設定を使うならtrue, モデルのカリング設定を使うならfalse
+     * @param drawableIndex drawable index
+     * @param value         true to use the SDK's culling settings, false to use the model's culling settings
      */
     public void setOverrideFlagForDrawableCullings(int drawableIndex, boolean value) {
         userDrawableCullings.get(drawableIndex).isOverridden = value;
@@ -2444,7 +1521,7 @@ public class CubismModel {
      * Checks whether the culling settings for the offscreen are overridden by the SDK.
      *
      * @param offscreenIndex offscreen index
-     * @return true if the culling settings from the SDK are used; otherwise false.
+     * @return true to use the SDK's culling settings, false to use the model's culling settings
      */
     public boolean getOverrideFlagForOffscreenCullings(int offscreenIndex) {
         return userOffscreenCullings.get(offscreenIndex).isOverridden;
@@ -2452,10 +1529,9 @@ public class CubismModel {
 
     /**
      * Sets whether the culling settings for the offscreen are overridden by the SDK.
-     * Use true to use the culling settings from the SDK, or false to use the culling settings from the model.
      *
      * @param offscreenIndex offscreen index
-     * @param value          true to use the override, false to keep the model's own culling settings
+     * @param value          true to use the SDK's culling settings, false to use the model's culling settings
      */
     public void setOverrideFlagForOffscreenCullings(int offscreenIndex, boolean value) {
         userOffscreenCullings.get(offscreenIndex).isOverridden = value;
@@ -2516,7 +1592,7 @@ public class CubismModel {
         parameterValues = model.getParameterViews();
         partValues = model.getPartViews();
 
-        // Set parameter IDs to _parameterIds.
+        // Parameter
         for (CubismParameterView parameterValue : parameterValues) {
             String id = parameterValue.getId();
 
@@ -2524,78 +1600,45 @@ public class CubismModel {
             userParameterRepeatDataList.add(new ParameterRepeatData(false, false));
         }
 
-        // Set part IDs to _partIds.
+        CubismDrawableView[] drawableValues = model.getDrawableViews();
+
+        final int partCount = partValues.length;
+        final int drawableCount = drawableValues.length;
+        final int offscreenCount = model.getOffscreenRenderingViews().length;
+
+        // Part
         for (CubismPartView partValue : partValues) {
             String id = partValue.getId();
-
             partIds.add(CubismFramework.getIdManager().getId(id));
         }
 
-        // Set drawable IDs to _drawableIds.
-        CubismDrawableView[] drawableValues = model.getDrawableViews();
-
-        // MultiplyColors
-        CubismRenderer.CubismTextureColor multiplyColor = new CubismRenderer.CubismTextureColor(
-            1.0f,
-            1.0f,
-            1.0f,
-            1.f
-        );
-        ColorData userDrawableMultiplyColor = new ColorData(false, multiplyColor);
-        ColorData userPartMultiplyColor = new ColorData(false, multiplyColor);
-
-        // ScreenColors
-        CubismRenderer.CubismTextureColor screenColor = new CubismRenderer.CubismTextureColor(
-            0.0f,
-            0.0f,
-            0.0f,
-            1.0f
-        );
-        ColorData userDrawableScreenColor = new ColorData(false, screenColor);
-        ColorData userPartScreenColor = new ColorData(false, screenColor);
-
-        // To prevent performance degradation due to capacity expansion, HashMap is generated with initial capacity reserved.
-        int partCount = model.getPartViews().length;
-        partChildDrawablesMap = new HashMap<Integer, List<Integer>>(partCount);
-
-        // Setting for Drawables.
+        // Drawable
         for (CubismDrawableView drawableValue : drawableValues) {
             String id = drawableValue.getId();
             drawableIds.add(CubismFramework.getIdManager().getId(id));
 
-            userDrawableMultiplyColors.add(new ColorData(userDrawableMultiplyColor));
-            userDrawableScreenColors.add(new ColorData(userDrawableScreenColor));
             userDrawableCullings.add(new CullingData(false, false));
 
+            // getDrawableBlendModeType()で都度newせずに済むよう事前確保しておく。
             drawableBlendModeTypes.add(new csmBlendMode());
-
-            // Bind parent Parts and child Drawables.
-            int parentIndex = drawableValue.getParentPartIndex();
-            if (parentIndex >= 0) {
-                List<Integer> childDrawables = partChildDrawablesMap.get(parentIndex);
-                if (childDrawables == null) {
-                    childDrawables = new ArrayList<Integer>();
-                    partChildDrawablesMap.put(parentIndex, childDrawables);
-                }
-                childDrawables.add(drawableValue.getIndex());
-            }
         }
-
-        // Setting for Parts.
-        for (int i = 0; i < partCount; i++) {
-            userPartMultiplyColors.add(new ColorData(userPartMultiplyColor));
-            userPartScreenColors.add(new ColorData(userPartScreenColor));
-        }
-
-        // blendMode
-        initializeBlendMode();
 
         // Offscreen
-        initializeOffscreen();
+        for (int i = 0; i < offscreenCount; i++) {
+            userOffscreenCullings.add(new CullingData());
 
-        if (isBlendModeEnabled) {
-            setupPartsHierarchy();
+            // getOffscreenBlendModeType()で都度newせずに済むよう事前確保しておく。
+            offscreenBlendModeTypes.add(new csmBlendMode());
         }
+
+        // Multiply and Screen
+        overrideMultiplyAndScreenColor.initialize(partCount, drawableCount, offscreenCount);
+
+        // BlendMode
+        initializeBlendMode();
+
+        // PartsHierarchy
+        setupPartsHierarchy();
     }
 
     /**
@@ -2633,47 +1676,6 @@ public class CubismModel {
                     break;
                 }
             }
-        }
-    }
-
-    /**
-     * Initializes offscreen rendering settings.
-     */
-    private void initializeOffscreen() {
-        // 乗算色
-        ColorData userMultiplyColor = new ColorData(
-            false,
-            new CubismRenderer.CubismTextureColor(
-                1.0f,
-                1.0f,
-                1.0f,
-                1.0f
-            )
-        );
-
-        // スクリーン色
-        ColorData userScreenColor = new ColorData(
-            false,
-            new CubismRenderer.CubismTextureColor(
-                0.0f,
-                0.0f,
-                0.0f,
-                1.0f
-            )
-        );
-
-        final int offscreenCount = model.getOffscreenRendering().getCount();
-
-        for (int i = 0; i < offscreenCount; i++) {
-            userOffscreenMultiplyColors.add(new ColorData(userMultiplyColor));
-            userOffscreenScreenColors.add(new ColorData(userScreenColor));
-            userOffscreenCullings.add(new CullingData());
-
-            offscreenBlendModeTypes.add(new csmBlendMode());
-
-            // キャッシュ用インスタンスをセットアップ
-            offscreenMultiplyColors.add(new CubismRenderer.CubismTextureColor());
-            offscreenScreenColors.add(new CubismRenderer.CubismTextureColor());
         }
     }
 
@@ -2748,75 +1750,6 @@ public class CubismModel {
     }
 
     /**
-     * PartのOverrideColorを設定する。
-     *
-     * @param partIndex 設定するPartのインデックス
-     * @param r 赤
-     * @param g 緑
-     * @param b 青
-     * @param a アルファ
-     * @param partColors 設定するPartの上書き色のリスト
-     * @param drawableColors Drawableの上書き色のリスト
-     */
-    private void setPartColor(
-        int partIndex,
-        float r, float g, float b, float a,
-        List<ColorData> partColors,
-        List<ColorData> drawableColors
-    ) {
-        partColors.get(partIndex).color.r = r;
-        partColors.get(partIndex).color.g = g;
-        partColors.get(partIndex).color.b = b;
-        partColors.get(partIndex).color.a = a;
-
-        if (partColors.get(partIndex).isOverridden) {
-            List<Integer> childDrawables = partChildDrawablesMap.get(partIndex);
-            if(childDrawables == null) return;
-
-            for (int i = 0; i < childDrawables.size(); i++) {
-                int drawableIndex = childDrawables.get(i);
-
-                drawableColors.get(drawableIndex).color.r = r;
-                drawableColors.get(drawableIndex).color.g = g;
-                drawableColors.get(drawableIndex).color.b = b;
-                drawableColors.get(drawableIndex).color.a = a;
-            }
-        }
-    }
-
-    /**
-     * PartのOverrideFlagを設定する。
-     *
-     * @param partIndex 設定するPartのインデックス
-     * @param value 真偽値
-     * @param partColors 設定するPartの上書き色のリスト
-     * @param drawableColors Drawableの上書き色のリスト
-     */
-    private void setOverrideColorsForPartColors(
-        int partIndex,
-        boolean value,
-        List<ColorData> partColors,
-        List<ColorData> drawableColors
-    ) {
-        partColors.get(partIndex).isOverridden = value;
-
-        List<Integer> childDrawables = partChildDrawablesMap.get(partIndex);
-        if (childDrawables == null) return;
-
-        for (int i = 0; i < childDrawables.size(); i++) {
-            int drawableIndex = childDrawables.get(i);
-            drawableColors.get(drawableIndex).isOverridden = value;
-
-            if (value) {
-                drawableColors.get(drawableIndex).color.r = partColors.get(partIndex).color.r;
-                drawableColors.get(drawableIndex).color.g = partColors.get(partIndex).color.g;
-                drawableColors.get(drawableIndex).color.b = partColors.get(partIndex).color.b;
-                drawableColors.get(drawableIndex).color.a = partColors.get(partIndex).color.a;
-            }
-        }
-    }
-
-    /**
      * List of opacities for non-existent parts
      */
     private float[] notExistPartOpacities = new float[1];
@@ -2856,38 +1789,12 @@ public class CubismModel {
     private final List<CubismId> partIds = new ArrayList<>();
     private final List<CubismId> drawableIds = new ArrayList<>();
 
-    /**
-     * Drawableの乗算色のリスト
-     */
-    private final List<ColorData> userDrawableMultiplyColors = new ArrayList<>();
-    /**
-     * Drawableのスクリーン色のリスト
-     */
-    private final List<ColorData> userDrawableScreenColors = new ArrayList<>();
+    private final List<CubismModelPartInfo> partsHierarchy = new ArrayList<>();
 
     /**
-     * パーツの乗算色のリスト
+     * List to manage ParameterRepeat and Override flag to be set for each Parameter
      */
-    private final List<ColorData> userPartMultiplyColors = new ArrayList<>();
-    /**
-     * パーツのスクリーン色のリスト
-     */
-    private final List<ColorData> userPartScreenColors = new ArrayList<>();
-
-    /**
-     * List of offscreen multiply colors.
-     */
-    private final List<ColorData> userOffscreenMultiplyColors = new ArrayList<>();
-
-    /**
-     * List of offscreen screen colors.
-     */
-    private final List<ColorData> userOffscreenScreenColors = new ArrayList<>();
-
-    /**
-     * Partとその子DrawableのListとのMap
-     */
-    private Map<Integer,List<Integer>> partChildDrawablesMap;
+    private final List<ParameterRepeatData> userParameterRepeatDataList = new ArrayList<>();
 
     /**
      * List of culling information for drawables.
@@ -2900,34 +1807,9 @@ public class CubismModel {
     private final List<CullingData> userOffscreenCullings = new ArrayList<>();
 
     /**
-     * List to manage ParameterRepeat and Override flag to be set for each Parameter
+     * Manager for multiply and screen color settings.
      */
-    private final List<ParameterRepeatData> userParameterRepeatDataList = new ArrayList<ParameterRepeatData>();
-
-    /**
-     * Flag whether to Override all the parameter repeat
-     */
-    private boolean isOverriddenParameterRepeat = true;
-
-    /**
-     * Flag whether to override all the multiply colors
-     */
-    private boolean isOverriddenModelMultiplyColors;
-    /**
-     * Flag whether to override all the screen colors
-     */
-    private boolean isOverriddenModelScreenColors;
-    /**
-     * モデルのカリング設定をすべて上書きするか？
-     */
-    private boolean isOverriddenCullings;
-
-    /**
-     * Flag whether blend mode is enabled for this model.
-     */
-    private boolean isBlendModeEnabled;
-
-    private final List<CubismModelPartInfo> partsHierarchy = new ArrayList<>();
+    private final CubismModelMultiplyAndScreenColor overrideMultiplyAndScreenColor = new CubismModelMultiplyAndScreenColor(this, partsHierarchy);
 
     /**
      * List of blend modes for each drawable.
@@ -2944,16 +1826,17 @@ public class CubismModel {
     private final List<csmBlendMode> offscreenBlendModeTypes = new ArrayList<>();
 
     /**
-     * List of multiply color instances for each offscreen.
-     * <p>
-     * Used to prevent generating instances each time the value is returned in {@link #getMultiplyColorOffscreen(int)}.
+     * Flag whether to Override all the parameter repeat
      */
-    private final List<CubismRenderer.CubismTextureColor> offscreenMultiplyColors = new ArrayList<>();
+    private boolean isOverriddenParameterRepeat = true;
 
     /**
-     * List of screen color instances for each offscreen.
-     * <p>
-     * Used to prevent generating instances each time the value is returned in {@link #getScreenColorOffscreen(int)}.
+     * Flag whether all cullings of the model are overridden by the SDK.
      */
-    private final List<CubismRenderer.CubismTextureColor> offscreenScreenColors = new ArrayList<>();
+    private boolean isOverriddenCullings;
+
+    /**
+     * Flag whether blend mode is enabled for this model.
+     */
+    private boolean isBlendModeEnabled;
 }

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismModelMultiplyAndScreenColor.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismModelMultiplyAndScreenColor.java
@@ -1,0 +1,863 @@
+/*
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at http://live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+package com.live2d.sdk.cubism.framework.model;
+
+import com.live2d.sdk.cubism.framework.rendering.CubismRenderer;
+import com.live2d.sdk.cubism.framework.utils.CubismDebug;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Handling multiply and screen colors of the model.
+ */
+public class CubismModelMultiplyAndScreenColor {
+    /**
+     * Structure for color information of drawing object.
+     */
+    public static class ColorData {
+        /**
+         * Constructor.
+         */
+        public ColorData() {
+            this.isOverridden = false;
+            this.color = new CubismRenderer.CubismTextureColor();
+        }
+
+        /**
+         * Constructor.
+         *
+         * @param isOverridden whether to be overridden
+         * @param color        texture color
+         */
+        public ColorData(boolean isOverridden, CubismRenderer.CubismTextureColor color) {
+            this.isOverridden = isOverridden;
+            this.color = new CubismRenderer.CubismTextureColor(color);
+        }
+
+        /**
+         * Copy constructor.
+         *
+         * @param other the ColorData object to copy from
+         */
+        public ColorData(ColorData other) {
+            this.isOverridden = other.isOverridden;
+            this.color = new CubismRenderer.CubismTextureColor(
+                other.color.r,
+                other.color.g,
+                other.color.b,
+                other.color.a
+            );
+        }
+
+        /**
+         * Whether to be overridden.
+         */
+        public boolean isOverridden;
+
+        /**
+         * Color.
+         */
+        public CubismRenderer.CubismTextureColor color;
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param model          cubism model
+     * @param partsHierarchy parts hierarchy
+     */
+    public CubismModelMultiplyAndScreenColor(CubismModel model, List<CubismModelPartInfo> partsHierarchy) {
+        this.model = model;
+        this.partsHierarchy = partsHierarchy;
+    }
+
+    /**
+     * Initializes user color data for multiply and screen colors.
+     *
+     * @param partCount      number of parts
+     * @param drawableCount  number of drawables
+     * @param offscreenCount number of offscreen
+     */
+    public void initialize(int partCount, int drawableCount, int offscreenCount) {
+        // 乗算色
+        ColorData userMultiplyColor = new ColorData(
+            false,
+            new CubismRenderer.CubismTextureColor(1.0f, 1.0f, 1.0f, 1.0f)
+        );
+
+        // スクリーン色
+        ColorData userScreenColor = new ColorData(
+            false,
+            new CubismRenderer.CubismTextureColor(0.0f, 0.0f, 0.0f, 1.0f)
+        );
+
+        // Part
+        for (int i = 0; i < partCount; i++) {
+            userPartMultiplyColors.add(new ColorData(userMultiplyColor));
+            userPartScreenColors.add(new ColorData(userScreenColor));
+        }
+
+        // Drawable
+        for (int i = 0; i < drawableCount; i++) {
+            userDrawableMultiplyColors.add(new ColorData(userMultiplyColor));
+            userDrawableScreenColors.add(new ColorData(userScreenColor));
+        }
+
+        // Offscreen
+        for (int i = 0; i < offscreenCount; i++) {
+            userOffscreenMultiplyColors.add(new ColorData(userMultiplyColor));
+            userOffscreenScreenColors.add(new ColorData(userScreenColor));
+
+            // getOffscreenMultiplyColor() / getOffscreenScreenColor() で都度 new せずに済むよう事前確保しておく。
+            offscreenMultiplyColorCache.add(new CubismRenderer.CubismTextureColor());
+            offscreenScreenColorCache.add(new CubismRenderer.CubismTextureColor());
+        }
+    }
+
+    /**
+     * Sets the flag indicating whether the color set at runtime is used as the multiply color for the entire model during rendering.
+     *
+     * @param value true if the color set at runtime is to be used; otherwise false.
+     */
+    public void setMultiplyColorEnabled(boolean value) {
+        isOverriddenModelMultiplyColors = value;
+    }
+
+    /**
+     * Returns the flag indicating whether the color set at runtime is used as the multiply color for the entire model during rendering.
+     *
+     * @return true if the color set at runtime is used; otherwise false.
+     */
+    public boolean getMultiplyColorEnabled() {
+        return isOverriddenModelMultiplyColors;
+    }
+
+    /**
+     * Sets the flag indicating whether the color set at runtime is used as the screen color for the entire model during rendering.
+     *
+     * @param value true if the color set at runtime is to be used; otherwise false.
+     */
+    public void setScreenColorEnabled(boolean value) {
+        isOverriddenModelScreenColors = value;
+    }
+
+    /**
+     * Returns the flag indicating whether the color set at runtime is used as the screen color for the entire model during rendering.
+     *
+     * @return true if the color set at runtime is used; otherwise false.
+     */
+    public boolean getScreenColorEnabled() {
+        return isOverriddenModelScreenColors;
+    }
+
+    /**
+     * Sets whether the part multiply color is overridden by the SDK.
+     * Use true to use the color information from the SDK, or false to use the color information from the model.
+     *
+     * @param partIndex part index
+     * @param value     true to enable override, false to disable
+     */
+    public void setPartMultiplyColorEnabled(int partIndex, boolean value) {
+        if (partIndex < 0 || model.getPartCount() <= partIndex) {
+            warnIndexOutOfRange("setPartMultiplyColorEnabled", partIndex, model.getPartCount() - 1);
+            return;
+        }
+
+        setPartColorEnabled(
+            partIndex,
+            value,
+            userPartMultiplyColors,
+            userDrawableMultiplyColors,
+            userOffscreenMultiplyColors
+        );
+    }
+
+    /**
+     * Checks whether the part multiply color is overridden by the SDK.
+     *
+     * @param partIndex part index
+     * @return true if the color information from the SDK is used; otherwise false.
+     */
+    public boolean getPartMultiplyColorEnabled(int partIndex) {
+        if (partIndex < 0 || model.getPartCount() <= partIndex) {
+            warnIndexOutOfRange("getPartMultiplyColorEnabled", partIndex, model.getPartCount() - 1);
+            return false;
+        }
+
+        return userPartMultiplyColors.get(partIndex).isOverridden;
+    }
+
+    /**
+     * Sets whether the part screen color is overridden by the SDK.
+     * Use true to use the color information from the SDK, or false to use the color information from the model.
+     *
+     * @param partIndex part index
+     * @param value     true to enable override, false to disable
+     */
+    public void setPartScreenColorEnabled(int partIndex, boolean value) {
+        if (partIndex < 0 || model.getPartCount() <= partIndex) {
+            warnIndexOutOfRange("setPartScreenColorEnabled", partIndex, model.getPartCount() - 1);
+            return;
+        }
+
+        setPartColorEnabled(
+            partIndex,
+            value,
+            userPartScreenColors,
+            userDrawableScreenColors,
+            userOffscreenScreenColors
+        );
+    }
+
+    /**
+     * Checks whether the part screen color is overridden by the SDK.
+     *
+     * @param partIndex part index
+     * @return true if the color information from the SDK is used; otherwise false.
+     */
+    public boolean getPartScreenColorEnabled(int partIndex) {
+        if (partIndex < 0 || model.getPartCount() <= partIndex) {
+            warnIndexOutOfRange("getPartScreenColorEnabled", partIndex, model.getPartCount() - 1);
+            return false;
+        }
+
+        return userPartScreenColors.get(partIndex).isOverridden;
+    }
+
+    /**
+     * Sets the multiply color of the part.
+     *
+     * @param partIndex part index
+     * @param color     multiply color to be set (CubismTextureColor)
+     */
+    public void setPartMultiplyColor(int partIndex, CubismRenderer.CubismTextureColor color) {
+        setPartMultiplyColor(partIndex, color.r, color.g, color.b, color.a);
+    }
+
+    /**
+     * Sets the multiply color of the part.
+     *
+     * @param partIndex part index
+     * @param r         red value of the multiply color to be set
+     * @param g         green value of the multiply color to be set
+     * @param b         blue value of the multiply color to be set
+     * @param a         alpha value of the multiply color to be set
+     */
+    public void setPartMultiplyColor(int partIndex, float r, float g, float b, float a) {
+        if (partIndex < 0 || model.getPartCount() <= partIndex) {
+            warnIndexOutOfRange("setPartMultiplyColor", partIndex, model.getPartCount() - 1);
+            return;
+        }
+
+        setPartColor(
+            partIndex,
+            r, g, b, a,
+            userPartMultiplyColors,
+            userDrawableMultiplyColors,
+            userOffscreenMultiplyColors
+        );
+    }
+
+    /**
+     * Returns the multiply color of the part.
+     *
+     * @param partIndex part index
+     * @return multiply color (CubismTextureColor)
+     */
+    public CubismRenderer.CubismTextureColor getPartMultiplyColor(int partIndex) {
+        if (partIndex < 0 || model.getPartCount() <= partIndex) {
+            warnIndexOutOfRange("getPartMultiplyColor", partIndex, model.getPartCount() - 1);
+            return new CubismRenderer.CubismTextureColor(1.0f, 1.0f, 1.0f, 1.0f);
+        }
+
+        return userPartMultiplyColors.get(partIndex).color;
+    }
+
+    /**
+     * Sets the screen color of the part.
+     *
+     * @param partIndex part index
+     * @param color     screen color to be set (CubismTextureColor)
+     */
+    public void setPartScreenColor(int partIndex, CubismRenderer.CubismTextureColor color) {
+        setPartScreenColor(partIndex, color.r, color.g, color.b, color.a);
+    }
+
+    /**
+     * Sets the screen color of the part.
+     *
+     * @param partIndex part index
+     * @param r         red value of the screen color to be set
+     * @param g         green value of the screen color to be set
+     * @param b         blue value of the screen color to be set
+     * @param a         alpha value of the screen color to be set
+     */
+    public void setPartScreenColor(int partIndex, float r, float g, float b, float a) {
+        if (partIndex < 0 || model.getPartCount() <= partIndex) {
+            warnIndexOutOfRange("setPartScreenColor", partIndex, model.getPartCount() - 1);
+            return;
+        }
+
+        setPartColor(
+            partIndex,
+            r, g, b, a,
+            userPartScreenColors,
+            userDrawableScreenColors,
+            userOffscreenScreenColors
+        );
+    }
+
+    /**
+     * Returns the screen color of the part.
+     *
+     * @param partIndex part index
+     * @return screen color (CubismTextureColor)
+     */
+    public CubismRenderer.CubismTextureColor getPartScreenColor(int partIndex) {
+        if (partIndex < 0 || model.getPartCount() <= partIndex) {
+            warnIndexOutOfRange("getPartScreenColor", partIndex, model.getPartCount() - 1);
+            return new CubismRenderer.CubismTextureColor(0.0f, 0.0f, 0.0f, 1.0f);
+        }
+
+        return userPartScreenColors.get(partIndex).color;
+    }
+
+    /**
+     * Sets the flag indicating whether the color set at runtime is used as the multiply color for the drawable during rendering.
+     *
+     * @param drawableIndex drawable index
+     * @param value         true if the color set at runtime is to be used; otherwise false.
+     */
+    public void setDrawableMultiplyColorEnabled(int drawableIndex, boolean value) {
+        if (drawableIndex < 0 || model.getDrawableCount() <= drawableIndex) {
+            warnIndexOutOfRange("setDrawableMultiplyColorEnabled", drawableIndex, model.getDrawableCount() - 1);
+            return;
+        }
+
+        userDrawableMultiplyColors.get(drawableIndex).isOverridden = value;
+    }
+
+    /**
+     * Returns the flag indicating whether the color set at runtime is used as the multiply color for the drawable during rendering.
+     *
+     * @param drawableIndex drawable index
+     * @return true if the color set at runtime is used; otherwise false.
+     */
+    public boolean getDrawableMultiplyColorEnabled(int drawableIndex) {
+        if (drawableIndex < 0 || model.getDrawableCount() <= drawableIndex) {
+            warnIndexOutOfRange("getDrawableMultiplyColorEnabled", drawableIndex, model.getDrawableCount() - 1);
+            return false;
+        }
+
+        return userDrawableMultiplyColors.get(drawableIndex).isOverridden;
+    }
+
+    /**
+     * Sets the flag indicating whether the color set at runtime is used as the screen color for the drawable during rendering.
+     *
+     * @param drawableIndex drawable index
+     * @param value         true if the color set at runtime is to be used; otherwise false.
+     */
+    public void setDrawableScreenColorEnabled(int drawableIndex, boolean value) {
+        if (drawableIndex < 0 || model.getDrawableCount() <= drawableIndex) {
+            warnIndexOutOfRange("setDrawableScreenColorEnabled", drawableIndex, model.getDrawableCount() - 1);
+            return;
+        }
+
+        userDrawableScreenColors.get(drawableIndex).isOverridden = value;
+    }
+
+    /**
+     * Returns the flag indicating whether the color set at runtime is used as the screen color for the drawable during rendering.
+     *
+     * @param drawableIndex drawable index
+     * @return true if the color set at runtime is used; otherwise false.
+     */
+    public boolean getDrawableScreenColorEnabled(int drawableIndex) {
+        if (drawableIndex < 0 || model.getDrawableCount() <= drawableIndex) {
+            warnIndexOutOfRange("getDrawableScreenColorEnabled", drawableIndex, model.getDrawableCount() - 1);
+            return false;
+        }
+
+        return userDrawableScreenColors.get(drawableIndex).isOverridden;
+    }
+
+    /**
+     * Sets the multiply color of the drawable.
+     *
+     * @param drawableIndex drawable index
+     * @param color         multiply color to be set (CubismTextureColor)
+     */
+    public void setDrawableMultiplyColor(int drawableIndex, CubismRenderer.CubismTextureColor color) {
+        setDrawableMultiplyColor(drawableIndex, color.r, color.g, color.b, color.a);
+    }
+
+    /**
+     * Sets the multiply color of the drawable.
+     *
+     * @param drawableIndex drawable index
+     * @param r             red value of the multiply color to be set
+     * @param g             green value of the multiply color to be set
+     * @param b             blue value of the multiply color to be set
+     * @param a             alpha value of the multiply color to be set
+     */
+    public void setDrawableMultiplyColor(int drawableIndex, float r, float g, float b, float a) {
+        if (drawableIndex < 0 || model.getDrawableCount() <= drawableIndex) {
+            warnIndexOutOfRange("setDrawableMultiplyColor", drawableIndex, model.getDrawableCount() - 1);
+            return;
+        }
+
+        userDrawableMultiplyColors.get(drawableIndex).color.r = r;
+        userDrawableMultiplyColors.get(drawableIndex).color.g = g;
+        userDrawableMultiplyColors.get(drawableIndex).color.b = b;
+        userDrawableMultiplyColors.get(drawableIndex).color.a = a;
+    }
+
+    /**
+     * Returns the multiply color from the list of drawables.
+     * <p>
+     * NOTE:
+     *  If the override flag is disabled, returns a cached copy of the model's original color.
+     *  If enabled, returns a reference to the user-overridden color.
+     *  Modifying the returned value mutates the cache or the user-overridden color data.
+     *  Since the cache is shared, even if a previously returned value is retained,
+     *  calling this method with a different {@code drawableIndex} overwrites it.
+     *
+     * @param drawableIndex drawable index
+     * @return multiply color (CubismTextureColor)
+     */
+    public CubismRenderer.CubismTextureColor getDrawableMultiplyColor(int drawableIndex) {
+        if (drawableIndex < 0 || model.getDrawableCount() <= drawableIndex) {
+            warnIndexOutOfRange("getDrawableMultiplyColor", drawableIndex, model.getDrawableCount() - 1);
+            return new CubismRenderer.CubismTextureColor(1.0f, 1.0f, 1.0f, 1.0f);
+        }
+
+        if (getMultiplyColorEnabled() || getDrawableMultiplyColorEnabled(drawableIndex)) {
+            return userDrawableMultiplyColors.get(drawableIndex).color;
+        }
+
+        final float[] tmpColor = model.getDrawableMultiplyColor(drawableIndex);
+        drawableMultiplyColorCache.r = tmpColor[0];
+        drawableMultiplyColorCache.g = tmpColor[1];
+        drawableMultiplyColorCache.b = tmpColor[2];
+        drawableMultiplyColorCache.a = tmpColor[3];
+
+        return drawableMultiplyColorCache;
+    }
+
+    /**
+     * Sets the screen color of the drawable.
+     *
+     * @param drawableIndex drawable index
+     * @param color         screen color to be set (CubismTextureColor)
+     */
+    public void setDrawableScreenColor(int drawableIndex, CubismRenderer.CubismTextureColor color) {
+        setDrawableScreenColor(drawableIndex, color.r, color.g, color.b, color.a);
+    }
+
+    /**
+     * Sets the screen color of the drawable.
+     *
+     * @param drawableIndex drawable index
+     * @param r             red value of the screen color to be set
+     * @param g             green value of the screen color to be set
+     * @param b             blue value of the screen color to be set
+     * @param a             alpha value of the screen color to be set
+     */
+    public void setDrawableScreenColor(int drawableIndex, float r, float g, float b, float a) {
+        if (drawableIndex < 0 || model.getDrawableCount() <= drawableIndex) {
+            warnIndexOutOfRange("setDrawableScreenColor", drawableIndex, model.getDrawableCount() - 1);
+            return;
+        }
+
+        userDrawableScreenColors.get(drawableIndex).color.r = r;
+        userDrawableScreenColors.get(drawableIndex).color.g = g;
+        userDrawableScreenColors.get(drawableIndex).color.b = b;
+        userDrawableScreenColors.get(drawableIndex).color.a = a;
+    }
+
+    /**
+     * Returns the screen color from the list of drawables.
+     * <p>
+     * NOTE:
+     *  If the override flag is disabled, returns a cached copy of the model's original color.
+     *  If enabled, returns a reference to the user-overridden color.
+     *  Modifying the returned value mutates the cache or the user-overridden color data.
+     *  Since the cache is shared, even if a previously returned value is retained,
+     *  calling this method with a different {@code drawableIndex} overwrites it.
+     *
+     * @param drawableIndex drawable index
+     * @return screen color (CubismTextureColor)
+     */
+    public CubismRenderer.CubismTextureColor getDrawableScreenColor(int drawableIndex) {
+        if (drawableIndex < 0 || model.getDrawableCount() <= drawableIndex) {
+            warnIndexOutOfRange("getDrawableScreenColor", drawableIndex, model.getDrawableCount() - 1);
+            return new CubismRenderer.CubismTextureColor(0.0f, 0.0f, 0.0f, 1.0f);
+        }
+
+        if (getScreenColorEnabled() || getDrawableScreenColorEnabled(drawableIndex)) {
+            return userDrawableScreenColors.get(drawableIndex).color;
+        }
+
+        final float[] tmpColor = model.getDrawableScreenColor(drawableIndex);
+        drawableScreenColorCache.r = tmpColor[0];
+        drawableScreenColorCache.g = tmpColor[1];
+        drawableScreenColorCache.b = tmpColor[2];
+        drawableScreenColorCache.a = tmpColor[3];
+
+        return drawableScreenColorCache;
+    }
+
+    /**
+     * Sets whether the offscreen multiply color is overridden by the SDK.
+     * Use true to use the color information from the SDK, or false to use the color information from the model.
+     *
+     * @param offscreenIndex offscreen index
+     * @param value          true to enable override, false to disable
+     */
+    public void setOffscreenMultiplyColorEnabled(int offscreenIndex, boolean value) {
+        if (offscreenIndex < 0 || model.getOffscreenCount() <= offscreenIndex) {
+            warnIndexOutOfRange("setOffscreenMultiplyColorEnabled", offscreenIndex, model.getOffscreenCount() - 1);
+            return;
+        }
+
+        userOffscreenMultiplyColors.get(offscreenIndex).isOverridden = value;
+    }
+
+    /**
+     * Checks whether the offscreen multiply color is overridden by the SDK.
+     *
+     * @param offscreenIndex offscreen index
+     * @return true if the color information from the SDK is used; otherwise false.
+     */
+    public boolean getOffscreenMultiplyColorEnabled(int offscreenIndex) {
+        if (offscreenIndex < 0 || model.getOffscreenCount() <= offscreenIndex) {
+            warnIndexOutOfRange("getOffscreenMultiplyColorEnabled", offscreenIndex, model.getOffscreenCount() - 1);
+            return false;
+        }
+
+        return userOffscreenMultiplyColors.get(offscreenIndex).isOverridden;
+    }
+
+    /**
+     * Sets whether the offscreen screen color is overridden by the SDK.
+     * Use true to use the color information from the SDK, or false to use the color information from the model.
+     *
+     * @param offscreenIndex offscreen index
+     * @param value          true to enable override, false to disable
+     */
+    public void setOffscreenScreenColorEnabled(int offscreenIndex, boolean value) {
+        if (offscreenIndex < 0 || model.getOffscreenCount() <= offscreenIndex) {
+            warnIndexOutOfRange("setOffscreenScreenColorEnabled", offscreenIndex, model.getOffscreenCount() - 1);
+            return;
+        }
+
+        userOffscreenScreenColors.get(offscreenIndex).isOverridden = value;
+    }
+
+    /**
+     * Checks whether the offscreen screen color is overridden by the SDK.
+     *
+     * @param offscreenIndex offscreen index
+     * @return true if the color information from the SDK is used; otherwise false.
+     */
+    public boolean getOffscreenScreenColorEnabled(int offscreenIndex) {
+        if (offscreenIndex < 0 || model.getOffscreenCount() <= offscreenIndex) {
+            warnIndexOutOfRange("getOffscreenScreenColorEnabled", offscreenIndex, model.getOffscreenCount() - 1);
+            return false;
+        }
+
+        return userOffscreenScreenColors.get(offscreenIndex).isOverridden;
+    }
+
+    /**
+     * Sets the multiply color of the offscreen.
+     *
+     * @param offscreenIndex offscreen index
+     * @param color          multiply color to be set (CubismTextureColor)
+     */
+    public void setOffscreenMultiplyColor(int offscreenIndex, CubismRenderer.CubismTextureColor color) {
+        setOffscreenMultiplyColor(offscreenIndex, color.r, color.g, color.b, color.a);
+    }
+
+    /**
+     * Sets the multiply color of the offscreen.
+     *
+     * @param offscreenIndex offscreen index
+     * @param r              red value of the multiply color to be set
+     * @param g              green value of the multiply color to be set
+     * @param b              blue value of the multiply color to be set
+     * @param a              alpha value of the multiply color to be set
+     */
+    public void setOffscreenMultiplyColor(int offscreenIndex, float r, float g, float b, float a) {
+        if (offscreenIndex < 0 || model.getOffscreenCount() <= offscreenIndex) {
+            warnIndexOutOfRange("setOffscreenMultiplyColor", offscreenIndex, model.getOffscreenCount() - 1);
+            return;
+        }
+
+        userOffscreenMultiplyColors.get(offscreenIndex).color.r = r;
+        userOffscreenMultiplyColors.get(offscreenIndex).color.g = g;
+        userOffscreenMultiplyColors.get(offscreenIndex).color.b = b;
+        userOffscreenMultiplyColors.get(offscreenIndex).color.a = a;
+    }
+
+    /**
+     * Returns the multiply color from the list of offscreen.
+     * <p>
+     * NOTE:
+     *  If the override flag is disabled, returns a cached copy of the model's original color.
+     *  If enabled, returns a reference to the user-overridden color.
+     *  Modifying the returned value mutates the cache or the user-overridden color data.
+     *  Since the cache is shared per {@code offscreenIndex}, even if a previously returned value is retained,
+     *  calling this method again with the same {@code offscreenIndex} overwrites it.
+     *
+     * @param offscreenIndex offscreen index
+     * @return multiply color (CubismTextureColor)
+     */
+    public CubismRenderer.CubismTextureColor getOffscreenMultiplyColor(int offscreenIndex) {
+        if (offscreenIndex < 0 || model.getOffscreenCount() <= offscreenIndex) {
+            warnIndexOutOfRange("getOffscreenMultiplyColor", offscreenIndex, model.getOffscreenCount() - 1);
+            return new CubismRenderer.CubismTextureColor(1.0f, 1.0f, 1.0f, 1.0f);
+        }
+
+        if (getMultiplyColorEnabled() || getOffscreenMultiplyColorEnabled(offscreenIndex)) {
+            return userOffscreenMultiplyColors.get(offscreenIndex).color;
+        }
+
+        final float[] tmpColor = model.getOffscreenMultiplyColor(offscreenIndex);
+
+        // インスタンス生成を避けるため、キャッシュリストからインスタンスを取得して値を更新
+        CubismRenderer.CubismTextureColor color = offscreenMultiplyColorCache.get(offscreenIndex);
+        color.r = tmpColor[0];
+        color.g = tmpColor[1];
+        color.b = tmpColor[2];
+        color.a = tmpColor[3];
+
+        return color;
+    }
+
+    /**
+     * Sets the screen color of the offscreen.
+     *
+     * @param offscreenIndex offscreen index
+     * @param color          screen color to be set (CubismTextureColor)
+     */
+    public void setOffscreenScreenColor(int offscreenIndex, CubismRenderer.CubismTextureColor color) {
+        setOffscreenScreenColor(offscreenIndex, color.r, color.g, color.b, color.a);
+    }
+
+    /**
+     * Sets the screen color of the offscreen.
+     *
+     * @param offscreenIndex offscreen index
+     * @param r              red value of the screen color to be set
+     * @param g              green value of the screen color to be set
+     * @param b              blue value of the screen color to be set
+     * @param a              alpha value of the screen color to be set
+     */
+    public void setOffscreenScreenColor(int offscreenIndex, float r, float g, float b, float a) {
+        if (offscreenIndex < 0 || model.getOffscreenCount() <= offscreenIndex) {
+            warnIndexOutOfRange("setOffscreenScreenColor", offscreenIndex, model.getOffscreenCount() - 1);
+            return;
+        }
+
+        userOffscreenScreenColors.get(offscreenIndex).color.r = r;
+        userOffscreenScreenColors.get(offscreenIndex).color.g = g;
+        userOffscreenScreenColors.get(offscreenIndex).color.b = b;
+        userOffscreenScreenColors.get(offscreenIndex).color.a = a;
+    }
+
+    /**
+     * Returns the screen color from the list of offscreen.
+     * <p>
+     * NOTE:
+     *  If the override flag is disabled, returns a cached copy of the model's original color.
+     *  If enabled, returns a reference to the user-overridden color.
+     *  Modifying the returned value mutates the cache or the user-overridden color data.
+     *  Since the cache is shared per {@code offscreenIndex}, even if a previously returned value is retained,
+     *  calling this method again with the same {@code offscreenIndex} overwrites it.
+     *
+     * @param offscreenIndex offscreen index
+     * @return screen color (CubismTextureColor)
+     */
+    public CubismRenderer.CubismTextureColor getOffscreenScreenColor(int offscreenIndex) {
+        if (offscreenIndex < 0 || model.getOffscreenCount() <= offscreenIndex) {
+            warnIndexOutOfRange("getOffscreenScreenColor", offscreenIndex, model.getOffscreenCount() - 1);
+            return new CubismRenderer.CubismTextureColor(0.0f, 0.0f, 0.0f, 1.0f);
+        }
+
+        if (getScreenColorEnabled() || getOffscreenScreenColorEnabled(offscreenIndex)) {
+            return userOffscreenScreenColors.get(offscreenIndex).color;
+        }
+
+        final float[] tmpColor = model.getOffscreenScreenColor(offscreenIndex);
+
+        // インスタンス生成を避けるため、キャッシュリストからインスタンスを取得して値を更新
+        CubismRenderer.CubismTextureColor color = offscreenScreenColorCache.get(offscreenIndex);
+        color.r = tmpColor[0];
+        color.g = tmpColor[1];
+        color.b = tmpColor[2];
+        color.a = tmpColor[3];
+
+        return color;
+    }
+
+    private static void warnIndexOutOfRange(String funcName, int index, int range) {
+        CubismDebug.cubismLogWarning("%s() : index is out of range. index = %d, valid range = [0, %d].", funcName, index, range);
+    }
+
+    private void setPartColor(
+        int partIndex,
+        float r, float g, float b, float a,
+        List<ColorData> partColors,
+        List<ColorData> drawableColors,
+        List<ColorData> offscreenColors
+    ) {
+        partColors.get(partIndex).color.r = r;
+        partColors.get(partIndex).color.g = g;
+        partColors.get(partIndex).color.b = b;
+        partColors.get(partIndex).color.a = a;
+
+        if (partColors.get(partIndex).isOverridden) {
+            final int offscreenIndex = model.getPartOffscreenIndices()[partIndex];
+            if (offscreenIndex == CubismModel.CubismNoIndex.OFFSCREEN.index) {
+                // If no offscreen buffer is attached, the effect is applied to the children.
+                List<CubismModelObjectInfo> objects = partsHierarchy.get(partIndex).objects;
+                for (int i = 0; i < objects.size(); i++) {
+                    CubismModelObjectInfo object = objects.get(i);
+                    if (object.objectType == CubismModelObjectInfo.ObjectType.DRAWABLE) {
+                        final int drawableIndex = object.objectIndex;
+                        drawableColors.get(drawableIndex).color.r = r;
+                        drawableColors.get(drawableIndex).color.g = g;
+                        drawableColors.get(drawableIndex).color.b = b;
+                        drawableColors.get(drawableIndex).color.a = a;
+                    } else {
+                        final int childPartIndex = object.objectIndex;
+                        setPartColor(
+                            childPartIndex,
+                            r, g, b, a,
+                            partColors,
+                            drawableColors,
+                            offscreenColors
+                        );
+                    }
+                }
+            } else {
+                // If an offscreen buffer is attached, only that offscreen buffer is affected.
+                offscreenColors.get(offscreenIndex).color.r = r;
+                offscreenColors.get(offscreenIndex).color.g = g;
+                offscreenColors.get(offscreenIndex).color.b = b;
+                offscreenColors.get(offscreenIndex).color.a = a;
+            }
+        }
+    }
+
+    private void setPartColorEnabled(
+        int partIndex,
+        boolean value,
+        List<ColorData> partColors,
+        List<ColorData> drawableColors,
+        List<ColorData> offscreenColors
+    ) {
+        partColors.get(partIndex).isOverridden = value;
+
+        final int offscreenIndex = model.getPartOffscreenIndices()[partIndex];
+        if (offscreenIndex == CubismModel.CubismNoIndex.OFFSCREEN.index) {
+            // If no offscreen buffer is attached, the effect is applied to the children.
+            List<CubismModelObjectInfo> objects = partsHierarchy.get(partIndex).objects;
+            for (int i = 0; i < objects.size(); i++) {
+                CubismModelObjectInfo object = objects.get(i);
+                if (object.objectType == CubismModelObjectInfo.ObjectType.DRAWABLE) {
+                    final int drawableIndex = object.objectIndex;
+                    drawableColors.get(drawableIndex).isOverridden = value;
+                    if (value) {
+                        drawableColors.get(drawableIndex).color.r = partColors.get(partIndex).color.r;
+                        drawableColors.get(drawableIndex).color.g = partColors.get(partIndex).color.g;
+                        drawableColors.get(drawableIndex).color.b = partColors.get(partIndex).color.b;
+                        drawableColors.get(drawableIndex).color.a = partColors.get(partIndex).color.a;
+                    }
+                } else {
+                    final int childPartIndex = object.objectIndex;
+                    if (value) {
+                        partColors.get(childPartIndex).color.r = partColors.get(partIndex).color.r;
+                        partColors.get(childPartIndex).color.g = partColors.get(partIndex).color.g;
+                        partColors.get(childPartIndex).color.b = partColors.get(partIndex).color.b;
+                        partColors.get(childPartIndex).color.a = partColors.get(partIndex).color.a;
+                    }
+                    setPartColorEnabled(
+                        childPartIndex,
+                        value,
+                        partColors,
+                        drawableColors,
+                        offscreenColors
+                    );
+                }
+            }
+        } else {
+            // If an offscreen buffer is attached, only that offscreen buffer is affected.
+            offscreenColors.get(offscreenIndex).isOverridden = value;
+            if (value) {
+                offscreenColors.get(offscreenIndex).color.r = partColors.get(partIndex).color.r;
+                offscreenColors.get(offscreenIndex).color.g = partColors.get(partIndex).color.g;
+                offscreenColors.get(offscreenIndex).color.b = partColors.get(partIndex).color.b;
+                offscreenColors.get(offscreenIndex).color.a = partColors.get(partIndex).color.a;
+            }
+        }
+    }
+
+    private final CubismModel model;
+
+    /**
+     * Reference to the parts hierarchy from the {@link CubismModel}, used in
+     * {@link #setPartColor} and {@link #setPartColorEnabled} to propagate colors
+     * along the parent-child structure.
+     */
+    private final List<CubismModelPartInfo> partsHierarchy;
+
+    /**
+     * Whether the multiply color override is enabled for the entire model.
+     */
+    private boolean isOverriddenModelMultiplyColors;
+
+    /**
+     * Whether the screen color override is enabled for the entire model.
+     */
+    private boolean isOverriddenModelScreenColors;
+
+    private final List<ColorData> userPartMultiplyColors = new ArrayList<>();
+    private final List<ColorData> userPartScreenColors = new ArrayList<>();
+    private final List<ColorData> userDrawableMultiplyColors = new ArrayList<>();
+    private final List<ColorData> userDrawableScreenColors = new ArrayList<>();
+    private final List<ColorData> userOffscreenMultiplyColors = new ArrayList<>();
+    private final List<ColorData> userOffscreenScreenColors = new ArrayList<>();
+
+    /**
+     * Single shared cache instance for {@link #getDrawableMultiplyColor(int)}
+     * to avoid creating a new instance every call.
+     */
+    private final CubismRenderer.CubismTextureColor drawableMultiplyColorCache = new CubismRenderer.CubismTextureColor();
+
+    /**
+     * Single shared cache instance for {@link #getDrawableScreenColor(int)}
+     * to avoid creating a new instance every call.
+     */
+    private final CubismRenderer.CubismTextureColor drawableScreenColorCache = new CubismRenderer.CubismTextureColor();
+
+    /**
+     * One cache instance per offscreenIndex for {@link #getOffscreenMultiplyColor(int)}
+     * to avoid creating a new instance every call.
+     */
+    private final List<CubismRenderer.CubismTextureColor> offscreenMultiplyColorCache = new ArrayList<>();
+
+    /**
+     * One cache instance per offscreenIndex for {@link #getOffscreenScreenColor(int)}
+     * to avoid creating a new instance every call.
+     */
+    private final List<CubismRenderer.CubismTextureColor> offscreenScreenColorCache = new ArrayList<>();
+}

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismModelObjectInfo.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismModelObjectInfo.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at http://live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+package com.live2d.sdk.cubism.framework.model;
+
+/**
+ * Information for a Cubism model object.
+ */
+public class CubismModelObjectInfo {
+    /**
+     * Type used in object information.
+     */
+    public enum ObjectType {
+        DRAWABLE(0),
+        PARTS(1);
+
+        public final int index;
+
+        ObjectType(int index) {
+            this.index = index;
+        }
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param objectIndex index of the object
+     * @param type        type of the object (Drawable or Parts)
+     */
+    public CubismModelObjectInfo(int objectIndex, ObjectType type) {
+        this.objectIndex = objectIndex;
+        this.objectType = type;
+    }
+
+    /**
+     * Type of the object (Drawable or Parts).
+     */
+    public ObjectType objectType;
+
+    /**
+     * Index of the object.
+     */
+    public int objectIndex;
+}

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismModelPartInfo.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismModelPartInfo.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at http://live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+package com.live2d.sdk.cubism.framework.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Information for a Cubism model part.
+ */
+public class CubismModelPartInfo {
+    /**
+     * Constructor.
+     */
+    public CubismModelPartInfo() {
+        objects = new ArrayList<>();
+        childDrawObjects = new PartChildDrawObjects();
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param objects          list of CubismModelObjectInfo
+     * @param childDrawObjects information of part child draw objects
+     */
+    public CubismModelPartInfo(List<CubismModelObjectInfo> objects, PartChildDrawObjects childDrawObjects) {
+        this.objects = new ArrayList<>(objects);
+        this.childDrawObjects = new PartChildDrawObjects(childDrawObjects);
+    }
+
+    /**
+     * Returns the number of child objects.
+     *
+     * @return number of child objects
+     */
+    public int getChildObjectCount() {
+        return objects.size();
+    }
+
+    /**
+     * List of object information.
+     */
+    public List<CubismModelObjectInfo> objects;
+
+    /**
+     * Information of part child draw objects.
+     */
+    public PartChildDrawObjects childDrawObjects;
+}

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismUserModel.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/model/CubismUserModel.java
@@ -14,6 +14,7 @@ import static com.live2d.sdk.cubism.framework.utils.CubismDebug.cubismLogInfo;
 
 import com.live2d.sdk.cubism.framework.effect.CubismBreath;
 import com.live2d.sdk.cubism.framework.effect.CubismEyeBlink;
+import com.live2d.sdk.cubism.framework.effect.CubismLook;
 import com.live2d.sdk.cubism.framework.effect.CubismPose;
 import com.live2d.sdk.cubism.framework.id.CubismId;
 import com.live2d.sdk.cubism.framework.math.CubismModelMatrix;
@@ -23,6 +24,7 @@ import com.live2d.sdk.cubism.framework.motion.CubismExpressionMotionManager;
 import com.live2d.sdk.cubism.framework.motion.CubismMotion;
 import com.live2d.sdk.cubism.framework.motion.CubismMotionManager;
 import com.live2d.sdk.cubism.framework.motion.CubismMotionQueueManager;
+import com.live2d.sdk.cubism.framework.motion.CubismUpdateScheduler;
 import com.live2d.sdk.cubism.framework.motion.IBeganMotionCallback;
 import com.live2d.sdk.cubism.framework.motion.ICubismMotionEventFunction;
 import com.live2d.sdk.cubism.framework.motion.IFinishedMotionCallback;
@@ -126,10 +128,24 @@ public abstract class CubismUserModel {
      * @param maskBufferCount 生成したいマスクバッファの枚数
      */
     public void setupRenderer(CubismRenderer renderer, int maskBufferCount) {
+        if (this.renderer != null) {
+            deleteRenderer();
+        }
+
         this.renderer = renderer;
 
         // Bind a renderer with a model instance
         this.renderer.initialize(model, maskBufferCount);
+    }
+
+    /**
+     * Delete the renderer.
+     */
+    public void deleteRenderer() {
+        if (renderer != null) {
+            renderer.close();
+            renderer = null;
+        }
     }
 
     /**
@@ -332,11 +348,10 @@ public abstract class CubismUserModel {
 
         moc.delete();
         model.close();
-        renderer.close();
+        deleteRenderer();
 
         moc = null;
         model = null;
-        renderer = null;
     }
 
     /**
@@ -473,6 +488,11 @@ public abstract class CubismUserModel {
     protected CubismModel model;
 
     /**
+     * Update scheduler that runs registered {@link com.live2d.sdk.cubism.framework.motion.ACubismUpdater} instances in order.
+     */
+    protected CubismUpdateScheduler updateScheduler = new CubismUpdateScheduler();
+
+    /**
      * A motion manager
      */
     protected CubismMotionManager motionManager = new CubismMotionManager();
@@ -509,6 +529,10 @@ public abstract class CubismUserModel {
      * A user data
      */
     protected CubismModelUserData modelUserData;
+    /**
+     * Parameter following feature by target (drag input).
+     */
+    protected CubismLook look;
 
     /**
      * An initializing status
@@ -523,21 +547,9 @@ public abstract class CubismUserModel {
      */
     protected float opacity = 1.0f;
     /**
-     * A lip-sync status
-     */
-    protected boolean lipSync = true;
-    /**
      * A control value of the last lip-sync
      */
     protected float lastLipSyncValue;
-    /**
-     * An X-position of mouse dragging
-     */
-    protected float dragX;
-    /**
-     * An Y-position of mouse dragging
-     */
-    protected float dragY;
     /**
      * An acceleration in X-axis direction
      */

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/model/PartChildDrawObjects.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/model/PartChildDrawObjects.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at http://live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+package com.live2d.sdk.cubism.framework.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Information for part child draw objects.
+ */
+public class PartChildDrawObjects {
+    /**
+     * Constructor.
+     */
+    public PartChildDrawObjects() {
+        drawableIndices = new ArrayList<>();
+        offscreenIndices = new ArrayList<>();
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param drawableIndices  list of Drawable indices
+     * @param offscreenIndices list of Offscreen indices
+     */
+    public PartChildDrawObjects(List<Integer> drawableIndices, List<Integer> offscreenIndices) {
+        this.drawableIndices = new ArrayList<>(drawableIndices);
+        this.offscreenIndices = new ArrayList<>(offscreenIndices);
+    }
+
+    /**
+     * Copy constructor.
+     *
+     * @param other the PartChildDrawObjects object to copy from
+     */
+    public PartChildDrawObjects(PartChildDrawObjects other) {
+        this.drawableIndices = new ArrayList<>(other.drawableIndices);
+        this.offscreenIndices = new ArrayList<>(other.offscreenIndices);
+    }
+
+    /**
+     * List of Drawable indices.
+     */
+    public List<Integer> drawableIndices;
+
+    /**
+     * List of Offscreen indices.
+     */
+    public List<Integer> offscreenIndices;
+}

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/ACubismUpdater.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/ACubismUpdater.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+package com.live2d.sdk.cubism.framework.motion;
+
+import com.live2d.sdk.cubism.framework.model.CubismModel;
+
+import java.util.Comparator;
+
+/**
+ * Abstract class for Updaters driven by {@link CubismUpdateScheduler}.
+ * Subclasses override {@link #onLateUpdate(CubismModel, float)} to apply their update.
+ * The executionOrder is set at construction.
+ */
+public abstract class ACubismUpdater {
+    /**
+     * Comparator that orders ACubismUpdater instances by executionOrder (ascending).
+     */
+    public static final Comparator<ACubismUpdater> COMPARATOR = new Comparator<ACubismUpdater>() {
+        @Override
+        public int compare(ACubismUpdater left, ACubismUpdater right) {
+            return Integer.compare(left.executionOrder, right.executionOrder);
+        }
+    };
+
+    /**
+     * Update process.
+     *
+     * @param model            the target model
+     * @param deltaTimeSeconds delta time[s]
+     */
+    public abstract void onLateUpdate(CubismModel model, float deltaTimeSeconds);
+
+    /**
+     * Constructor that uses {@link CubismUpdateOrder#MAX} as the execution order.
+     */
+    public ACubismUpdater() {
+        this(CubismUpdateOrder.MAX);
+    }
+
+    /**
+     * Constructor with a predefined execution order from {@link CubismUpdateOrder}.
+     *
+     * @param executionOrder one of {@link CubismUpdateOrder}
+     */
+    public ACubismUpdater(CubismUpdateOrder executionOrder) {
+        this(executionOrder.order);
+    }
+
+    /**
+     * Constructor with an arbitrary execution order (for values not defined in {@link CubismUpdateOrder}).
+     *
+     * @param executionOrder the execution order
+     */
+    public ACubismUpdater(int executionOrder) {
+        this.executionOrder = executionOrder;
+    }
+
+    private final int executionOrder;
+}

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismBreathUpdater.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismBreathUpdater.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+package com.live2d.sdk.cubism.framework.motion;
+
+import com.live2d.sdk.cubism.framework.effect.CubismBreath;
+import com.live2d.sdk.cubism.framework.model.CubismModel;
+
+/**
+ * Updater for breathing motion.
+ * Registered with {@link CubismUpdateScheduler} and executed in executionOrder.
+ */
+public class CubismBreathUpdater extends ACubismUpdater {
+    /**
+     * Constructor with the default execution order ({@link CubismUpdateOrder#BREATH}).
+     *
+     * @param breath CubismBreath instance
+     */
+    public CubismBreathUpdater(CubismBreath breath) {
+        super(CubismUpdateOrder.BREATH);
+        this.breath = breath;
+    }
+
+    /**
+     * Constructor with an arbitrary execution order (for values not defined in {@link CubismUpdateOrder}).
+     *
+     * @param breath         CubismBreath instance
+     * @param executionOrder the execution order
+     */
+    public CubismBreathUpdater(CubismBreath breath, int executionOrder) {
+        super(executionOrder);
+        this.breath = breath;
+    }
+
+    @Override
+    public void onLateUpdate(CubismModel model, final float deltaTimeSeconds) {
+        if (model == null) {
+            return;
+        }
+        breath.updateParameters(model, deltaTimeSeconds);
+    }
+
+    private final CubismBreath breath;
+}

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismExpressionUpdater.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismExpressionUpdater.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+package com.live2d.sdk.cubism.framework.motion;
+
+import com.live2d.sdk.cubism.framework.model.CubismModel;
+
+/**
+ * Updater for expression motion.
+ * Registered with {@link CubismUpdateScheduler} and executed in executionOrder.
+ */
+public class CubismExpressionUpdater extends ACubismUpdater {
+    /**
+     * Constructor with the default execution order ({@link CubismUpdateOrder#EXPRESSION}).
+     *
+     * @param expressionManager CubismExpressionMotionManager instance
+     */
+    public CubismExpressionUpdater(CubismExpressionMotionManager expressionManager) {
+        super(CubismUpdateOrder.EXPRESSION);
+        this.expressionManager = expressionManager;
+    }
+
+    /**
+     * Constructor with an arbitrary execution order (for values not defined in {@link CubismUpdateOrder}).
+     *
+     * @param expressionManager CubismExpressionMotionManager instance
+     * @param executionOrder    the execution order
+     */
+    public CubismExpressionUpdater(CubismExpressionMotionManager expressionManager, int executionOrder) {
+        super(executionOrder);
+        this.expressionManager = expressionManager;
+    }
+
+    @Override
+    public void onLateUpdate(CubismModel model, final float deltaTimeSeconds) {
+        if (model == null) {
+            return;
+        }
+        // Update parameters by expression (relative change).
+        expressionManager.updateMotion(model, deltaTimeSeconds);
+    }
+
+    private final CubismExpressionMotionManager expressionManager;
+}

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismEyeBlinkUpdater.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismEyeBlinkUpdater.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+package com.live2d.sdk.cubism.framework.motion;
+
+import com.live2d.sdk.cubism.framework.effect.CubismEyeBlink;
+import com.live2d.sdk.cubism.framework.model.CubismModel;
+
+/**
+ * Updater for eye blink motion.
+ * Registered with {@link CubismUpdateScheduler} and executed in executionOrder.
+ */
+public class CubismEyeBlinkUpdater extends ACubismUpdater {
+    /**
+     * Constructor with the default execution order ({@link CubismUpdateOrder#EYE_BLINK}).
+     *
+     * @param motionUpdated supplier that returns the latest motion update flag
+     * @param eyeBlink      CubismEyeBlink instance
+     */
+    public CubismEyeBlinkUpdater(IBooleanSupplier motionUpdated, CubismEyeBlink eyeBlink) {
+        super(CubismUpdateOrder.EYE_BLINK);
+        this.motionUpdated = motionUpdated;
+        this.eyeBlink = eyeBlink;
+    }
+
+    /**
+     * Constructor with an arbitrary execution order (for values not defined in {@link CubismUpdateOrder}).
+     *
+     * @param motionUpdated  supplier that returns the latest motion update flag
+     * @param eyeBlink       CubismEyeBlink instance
+     * @param executionOrder the execution order
+     */
+    public CubismEyeBlinkUpdater(IBooleanSupplier motionUpdated, CubismEyeBlink eyeBlink, int executionOrder) {
+        super(executionOrder);
+        this.motionUpdated = motionUpdated;
+        this.eyeBlink = eyeBlink;
+    }
+
+    @Override
+    public void onLateUpdate(CubismModel model, final float deltaTimeSeconds) {
+        if (model == null) {
+            return;
+        }
+
+        if (!motionUpdated.getAsBoolean()) {
+            // Skip eye blink update when the main motion did not update parameters.
+            eyeBlink.updateParameters(model, deltaTimeSeconds);
+        }
+    }
+
+    /**
+     * Supplier of the owner's motion-updated flag.
+     * Eye blink runs only when the main motion did not update parameters this frame.
+     */
+    private final IBooleanSupplier motionUpdated;
+    private final CubismEyeBlink eyeBlink;
+}

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismLipSyncUpdater.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismLipSyncUpdater.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+package com.live2d.sdk.cubism.framework.motion;
+
+import com.live2d.sdk.cubism.framework.id.CubismId;
+import com.live2d.sdk.cubism.framework.model.CubismModel;
+
+import java.util.List;
+
+/**
+ * Updater for lip sync motion.
+ * Registered with {@link CubismUpdateScheduler} and executed in executionOrder.
+ */
+public class CubismLipSyncUpdater extends ACubismUpdater {
+    /**
+     * Constructor with the default execution order ({@link CubismUpdateOrder#LIP_SYNC}).
+     *
+     * @param lipSyncIds     parameter IDs targeted by lip sync
+     * @param wavFileHandler IParameterProvider that supplies the lip sync value
+     */
+    public CubismLipSyncUpdater(List<CubismId> lipSyncIds, IParameterProvider wavFileHandler) {
+        super(CubismUpdateOrder.LIP_SYNC);
+        this.lipSyncIds = lipSyncIds;
+        this.wavFileHandler = wavFileHandler;
+    }
+
+    /**
+     * Constructor with an arbitrary execution order (for values not defined in {@link CubismUpdateOrder}).
+     *
+     * @param lipSyncIds     parameter IDs targeted by lip sync
+     * @param wavFileHandler IParameterProvider that supplies the lip sync value
+     * @param executionOrder the execution order
+     */
+    public CubismLipSyncUpdater(List<CubismId> lipSyncIds, IParameterProvider wavFileHandler, int executionOrder) {
+        super(executionOrder);
+        this.lipSyncIds = lipSyncIds;
+        this.wavFileHandler = wavFileHandler;
+    }
+
+    @Override
+    public void onLateUpdate(CubismModel model, final float deltaTimeSeconds) {
+        if (model == null) {
+            return;
+        }
+
+        // For real-time lip sync, the wavFileHandler returns the system volume in the [0, 1] range,
+        // which is then applied to the lip sync parameters below.
+        wavFileHandler.update(deltaTimeSeconds);
+        float value = wavFileHandler.getParameter();
+
+        for (int i = 0; i < lipSyncIds.size(); i++) {
+            model.addParameterValue(lipSyncIds.get(i), value, 0.8f);
+        }
+    }
+
+    private final IParameterProvider wavFileHandler;
+    private final List<CubismId> lipSyncIds;
+}

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismLookUpdater.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismLookUpdater.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+package com.live2d.sdk.cubism.framework.motion;
+
+import com.live2d.sdk.cubism.framework.effect.CubismLook;
+import com.live2d.sdk.cubism.framework.math.CubismTargetPoint;
+import com.live2d.sdk.cubism.framework.model.CubismModel;
+
+/**
+ * Updater for drag-driven look motion.
+ * Registered with {@link CubismUpdateScheduler} and executed in executionOrder.
+ * <p>
+ * Note:
+ *  this updater drives the dragManager smoothing via {@code dragManager.update}.
+ *  If omitted, drag smoothing will not run.
+ */
+public class CubismLookUpdater extends ACubismUpdater {
+    /**
+     * Constructor with the default execution order ({@link CubismUpdateOrder#LOOK}).
+     *
+     * @param look        CubismLook instance
+     * @param dragManager CubismTargetPoint instance
+     */
+    public CubismLookUpdater(CubismLook look, CubismTargetPoint dragManager) {
+        super(CubismUpdateOrder.LOOK);
+        this.look = look;
+        this.dragManager = dragManager;
+    }
+
+    /**
+     * Constructor with an arbitrary execution order (for values not defined in {@link CubismUpdateOrder}).
+     *
+     * @param look           CubismLook instance
+     * @param dragManager    CubismTargetPoint instance
+     * @param executionOrder the execution order
+     */
+    public CubismLookUpdater(CubismLook look, CubismTargetPoint dragManager, int executionOrder) {
+        super(executionOrder);
+        this.look = look;
+        this.dragManager = dragManager;
+    }
+
+    @Override
+    public void onLateUpdate(CubismModel model, final float deltaTimeSeconds) {
+        if (model == null) {
+            return;
+        }
+
+        dragManager.update(deltaTimeSeconds);
+        final float dragX = dragManager.getX();
+        final float dragY = dragManager.getY();
+
+        look.updateParameters(model, dragX, dragY);
+    }
+
+    private final CubismLook look;
+    private final CubismTargetPoint dragManager;
+}

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismMotionInternal.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismMotionInternal.java
@@ -184,6 +184,7 @@ class CubismMotionInternal {
     /**
      * For strategy pattern.
      */
+    @FunctionalInterface
     public interface CsmMotionSegmentEvaluationFunction {
         float evaluate(final List<CubismMotionPoint> points, final float time);
     }

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismPhysicsUpdater.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismPhysicsUpdater.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+package com.live2d.sdk.cubism.framework.motion;
+
+import com.live2d.sdk.cubism.framework.model.CubismModel;
+import com.live2d.sdk.cubism.framework.physics.CubismPhysics;
+
+/**
+ * Updater for physics motion.
+ * Registered with {@link CubismUpdateScheduler} and executed in executionOrder.
+ */
+public class CubismPhysicsUpdater extends ACubismUpdater {
+    /**
+     * Constructor with the default execution order ({@link CubismUpdateOrder#PHYSICS}).
+     *
+     * @param physics CubismPhysics instance
+     */
+    public CubismPhysicsUpdater(CubismPhysics physics) {
+        super(CubismUpdateOrder.PHYSICS);
+        this.physics = physics;
+    }
+
+    /**
+     * Constructor with an arbitrary execution order (for values not defined in {@link CubismUpdateOrder}).
+     *
+     * @param physics        CubismPhysics instance
+     * @param executionOrder the execution order
+     */
+    public CubismPhysicsUpdater(CubismPhysics physics, int executionOrder) {
+        super(executionOrder);
+        this.physics = physics;
+    }
+
+    @Override
+    public void onLateUpdate(CubismModel model, final float deltaTimeSeconds) {
+        if (model == null) {
+            return;
+        }
+        physics.evaluate(model, deltaTimeSeconds);
+    }
+
+    private final CubismPhysics physics;
+}

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismPoseUpdater.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismPoseUpdater.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+package com.live2d.sdk.cubism.framework.motion;
+
+import com.live2d.sdk.cubism.framework.effect.CubismPose;
+import com.live2d.sdk.cubism.framework.model.CubismModel;
+
+/**
+ * Updater for pose motion.
+ * Registered with {@link CubismUpdateScheduler} and executed in executionOrder.
+ */
+public class CubismPoseUpdater extends ACubismUpdater {
+    /**
+     * Constructor with the default execution order ({@link CubismUpdateOrder#POSE}).
+     *
+     * @param pose CubismPose instance
+     */
+    public CubismPoseUpdater(CubismPose pose) {
+        super(CubismUpdateOrder.POSE);
+        this.pose = pose;
+    }
+
+    /**
+     * Constructor with an arbitrary execution order (for values not defined in {@link CubismUpdateOrder}).
+     *
+     * @param pose           CubismPose instance
+     * @param executionOrder the execution order
+     */
+    public CubismPoseUpdater(CubismPose pose, int executionOrder) {
+        super(executionOrder);
+        this.pose = pose;
+    }
+
+    @Override
+    public void onLateUpdate(CubismModel model, final float deltaTimeSeconds) {
+        if (model == null) {
+            return;
+        }
+        pose.updateParameters(model, deltaTimeSeconds);
+    }
+
+    private final CubismPose pose;
+}

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismUpdateOrder.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismUpdateOrder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+package com.live2d.sdk.cubism.framework.motion;
+
+/**
+ * Default execution order values for {@link ACubismUpdater} instances.
+ * <p>
+ * Smaller values are executed first by {@link CubismUpdateScheduler}.
+ * Users can pass arbitrary int values to {@link ACubismUpdater} to customize the order.
+ */
+public enum CubismUpdateOrder {
+    EYE_BLINK(200),
+    EXPRESSION(300),
+    LOOK(400),
+    BREATH(500),
+    PHYSICS(600),
+    LIP_SYNC(700),
+    POSE(800),
+    MAX(Integer.MAX_VALUE);
+
+    public final int order;
+
+    CubismUpdateOrder(int order) {
+        this.order = order;
+    }
+}

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismUpdateScheduler.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/CubismUpdateScheduler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+package com.live2d.sdk.cubism.framework.motion;
+
+import com.live2d.sdk.cubism.framework.model.CubismModel;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Holds registered {@link ACubismUpdater} instances and runs them in order of executionOrder.
+ */
+public class CubismUpdateScheduler {
+    /**
+     * Adds an {@link ACubismUpdater} to the update list.
+     *
+     * @param updatable the {@link ACubismUpdater} instance to be added
+     */
+    public void addUpdatableList(ACubismUpdater updatable) {
+        if (updatable == null) {
+            return;
+        }
+        cubismUpdatableList.add(updatable);
+        needsSort = true;
+    }
+
+    /**
+     * Sorts the update list in ascending order of executionOrder.
+     */
+    public void sortUpdatableList() {
+        Collections.sort(cubismUpdatableList, ACubismUpdater.COMPARATOR);
+        needsSort = false;
+    }
+
+    /**
+     * Updates every element in the list.
+     *
+     * @param model            the target model
+     * @param deltaTimeSeconds delta time[s]
+     */
+    public void onLateUpdate(CubismModel model, final float deltaTimeSeconds) {
+        if (needsSort) {
+            sortUpdatableList();
+        }
+
+        for (int i = 0; i < cubismUpdatableList.size(); i++) {
+            cubismUpdatableList.get(i).onLateUpdate(model, deltaTimeSeconds);
+        }
+    }
+
+    private final List<ACubismUpdater> cubismUpdatableList = new ArrayList<ACubismUpdater>();
+    private boolean needsSort = true;
+}

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/IBeganMotionCallback.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/IBeganMotionCallback.java
@@ -10,6 +10,7 @@ package com.live2d.sdk.cubism.framework.motion;
 /**
  * モーション再生開始コールバック
  */
+@FunctionalInterface
 public interface IBeganMotionCallback {
     void execute(ACubismMotion motion);
 }

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/IBooleanSupplier.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/IBooleanSupplier.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+package com.live2d.sdk.cubism.framework.motion;
+
+/**
+ * Functional interface that returns a boolean on each call.
+ * Defined here because the framework targets Java 7 (Java 8's
+ * {@code java.util.function.BooleanSupplier} is unavailable).
+ *
+ * <p>Provides on-demand access to a specific boolean state. For example:
+ * <pre>{@code
+ * updateScheduler.addUpdatableList(new CubismEyeBlinkUpdater(new IBooleanSupplier() {
+ *     public boolean getAsBoolean() {
+ *         return motionUpdated;
+ *     }
+ * }, eyeBlink));
+ * }</pre>
+ */
+@FunctionalInterface
+public interface IBooleanSupplier {
+    /**
+     * Returns the latest boolean value.
+     *
+     * @return the current boolean
+     */
+    boolean getAsBoolean();
+}

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/ICubismMotionEventFunction.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/ICubismMotionEventFunction.java
@@ -7,6 +7,7 @@
 
 package com.live2d.sdk.cubism.framework.motion;
 
+@FunctionalInterface
 public interface ICubismMotionEventFunction {
     void apply(
         CubismMotionQueueManager caller,

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/IFinishedMotionCallback.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/IFinishedMotionCallback.java
@@ -10,6 +10,7 @@ package com.live2d.sdk.cubism.framework.motion;
 /**
  * モーション再生終了コールバック
  */
+@FunctionalInterface
 public interface IFinishedMotionCallback {
     void execute(ACubismMotion motion);
 }

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/IParameterProvider.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/motion/IParameterProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+package com.live2d.sdk.cubism.framework.motion;
+
+/**
+ * Interface for providing parameter values.
+ * Defines the interface for classes that supply parameter values to the model.
+ */
+public interface IParameterProvider {
+    /**
+     * Update process.
+     *
+     * @return true if the update is successful
+     */
+    boolean update();
+
+    /**
+     * Update process.
+     *
+     * @param deltaTimeSeconds delta time[s]
+     * @return true if the update is successful
+     */
+    boolean update(float deltaTimeSeconds);
+
+    /**
+     * Retrieves the current value of the parameter.
+     *
+     * @return the parameter value as a float
+     */
+    float getParameter();
+}

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/physics/CubismPhysicsInternal.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/physics/CubismPhysicsInternal.java
@@ -300,6 +300,7 @@ public class CubismPhysicsInternal {
     /**
      * Functional interface with a function which gets normalized parameters.
      */
+    @FunctionalInterface
     public interface NormalizedPhysicsParameterValueGetter {
         /**
          * Get normalized parameters.
@@ -332,6 +333,7 @@ public class CubismPhysicsInternal {
     /**
      * Functional interface with a function for getting values of physics operations.
      */
+    @FunctionalInterface
     public interface PhysicsValueGetter {
         /**
          * Get values of physics operations.
@@ -356,6 +358,7 @@ public class CubismPhysicsInternal {
     /**
      * Functional interface with a function for getting the scale of physics operations.
      */
+    @FunctionalInterface
     public interface PhysicsScaleGetter {
         /**
          * Get a scale of physics operations.

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/ACubismClippingManager.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/ACubismClippingManager.java
@@ -14,6 +14,7 @@ import static com.live2d.sdk.cubism.framework.utils.CubismDebug.cubismLogError;
 import com.live2d.sdk.cubism.framework.math.CubismMatrix44;
 import com.live2d.sdk.cubism.framework.math.CubismVector2;
 import com.live2d.sdk.cubism.framework.model.CubismModel;
+import com.live2d.sdk.cubism.framework.model.PartChildDrawObjects;
 import com.live2d.sdk.cubism.framework.type.csmRectF;
 
 import java.io.Closeable;
@@ -24,7 +25,7 @@ import java.util.List;
  * クリッピングマネージャーの抽象骨格クラス
  *
  * @param <T_ClippingContext> ACubismClippingContextを継承した型
- * @param <T_RenderTarget>  CubismOffscreenSurface型
+ * @param <T_RenderTarget>  CubismRenderTarget型
  */
 public abstract class ACubismClippingManager<
     T_ClippingContext extends ACubismClippingContext,
@@ -643,7 +644,7 @@ public abstract class ACubismClippingManager<
         int partIndex,
         List<Integer> childDrawableIndexList
     ) {
-        CubismModel.PartChildDrawObjects childDrawObjects = model.getPartsHierarchy().get(partIndex).childDrawObjects;
+        PartChildDrawObjects childDrawObjects = model.getPartsHierarchy().get(partIndex).childDrawObjects;
         for (int i = 0; i < childDrawObjects.drawableIndices.size(); i++) {
             childDrawableIndexList.add(childDrawObjects.drawableIndices.get(i));
         }

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/CubismRenderer.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/CubismRenderer.java
@@ -152,9 +152,7 @@ public abstract class CubismRenderer {
      */
     abstract public void initialize(CubismModel model, int maskBufferCount);
 
-    public void close() {
-        model.close();
-    }
+    public void close() {}
 
     /**
      * Draw the model.

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismRenderTargetAndroid.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismRenderTargetAndroid.java
@@ -27,16 +27,16 @@ public class CubismRenderTargetAndroid implements ICubismRenderTarget {
     /**
      * Copy constructor
      *
-     * @param offscreenSurface offscreen surface buffer
+     * @param renderTarget the render target to copy from
      */
-    public CubismRenderTargetAndroid(CubismRenderTargetAndroid offscreenSurface) {
-        renderTexture = Arrays.copyOf(offscreenSurface.renderTexture, offscreenSurface.renderTexture.length);
-        colorBuffer = Arrays.copyOf(offscreenSurface.colorBuffer, offscreenSurface.colorBuffer.length);
-        oldFBO = Arrays.copyOf(offscreenSurface.oldFBO, offscreenSurface.oldFBO.length);
+    public CubismRenderTargetAndroid(CubismRenderTargetAndroid renderTarget) {
+        renderTexture = Arrays.copyOf(renderTarget.renderTexture, renderTarget.renderTexture.length);
+        colorBuffer = Arrays.copyOf(renderTarget.colorBuffer, renderTarget.colorBuffer.length);
+        oldFBO = Arrays.copyOf(renderTarget.oldFBO, renderTarget.oldFBO.length);
 
-        bufferWidth = offscreenSurface.bufferWidth;
-        bufferHeight = offscreenSurface.bufferHeight;
-        isColorBufferInherited = offscreenSurface.isColorBufferInherited;
+        bufferWidth = renderTarget.bufferWidth;
+        bufferHeight = renderTarget.bufferHeight;
+        isColorBufferInherited = renderTarget.isColorBufferInherited;
     }
 
     @Override
@@ -83,7 +83,7 @@ public class CubismRenderTargetAndroid implements ICubismRenderTarget {
     }
 
     /**
-     * Create CubismOffscreenSurface.
+     * Create CubismRenderTarget.
      * <p>
      * This method reproduces default argument of C++. The users can use this method instead of specifying null as colorBuffer(2rd) argument.
      * </p>
@@ -124,7 +124,7 @@ public class CubismRenderTargetAndroid implements ICubismRenderTarget {
 
         int[] ret = new int[1];
 
-        // Create new offscreen surface
+        // Create new render target
         if (colorBuffer == null) {
             this.colorBuffer = new int[1];
             glGenTextures(1, this.colorBuffer, 0);
@@ -142,8 +142,8 @@ public class CubismRenderTargetAndroid implements ICubismRenderTarget {
                 null);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
             glBindTexture(GL_TEXTURE_2D, 0);
 
             isColorBufferInherited = false;

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismRendererAndroid.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismRendererAndroid.java
@@ -94,7 +94,6 @@ public class CubismRendererAndroid extends CubismRenderer {
 
         if (model.isUsingMasking()) {
             // マスクバッファの枚数として、0または負の値が指定されている場合は強制的に1枚と設定し、警告ログを出力する。
-            // Webと違いCubismOffscreenSurfaceの配列を作成するため、こちらで不正値を検知し修正する。
             if (maskBufferCount < 1) {
                 maskBufferCount = 1;
                 CubismDebug.cubismLogWarning("The number of render textures must be an integer greater than or equal to 1. Set the number of render textures to 1.");
@@ -162,6 +161,9 @@ public class CubismRendererAndroid extends CubismRenderer {
         }
 
         super.initialize(model);
+
+        // シェーダの事前初期化
+        CubismShaderAndroid.getInstance();
     }
 
     /**
@@ -451,18 +453,21 @@ public class CubismRendererAndroid extends CubismRenderer {
             CubismShaderAndroid.getInstance().setupShaderProgramForDrawable(this, model, index);
         }
 
-        // Draw the prygon mesh
-        final int indexCount = model.getDrawableVertexIndexCount(index);
-        final ShortBuffer indexArrayBuffer = drawableInfoCachesHolder.setUpIndexArray(
-            index,
-            model.getDrawableVertexIndices(index)
-        );
-        glDrawElements(
-            GL_TRIANGLES,
-            indexCount,
-            GL_UNSIGNED_SHORT,
-            indexArrayBuffer
-        );
+        // ポリゴンメッシュを描画する
+        glGetIntegerv(GL_CURRENT_PROGRAM, currentProgram, 0);
+        if (currentProgram[0] != 0) {
+            final int indexCount = model.getDrawableVertexIndexCount(index);
+            final ShortBuffer indexArrayBuffer = drawableInfoCachesHolder.setUpIndexArray(
+                index,
+                model.getDrawableVertexIndices(index)
+            );
+            glDrawElements(
+                GL_TRIANGLES,
+                indexCount,
+                GL_UNSIGNED_SHORT,
+                indexArrayBuffer
+            );
+        }
 
         // post-processing
         glUseProgram(0);
@@ -1197,6 +1202,12 @@ public class CubismRendererAndroid extends CubismRenderer {
      * Root frame buffer for model rendering.
      */
     private int[] modelRootFBO = new int[1];
+
+    /**
+     * Buffer for retrieving the current shader program.
+     * Defined as a field to avoid allocating a new array every frame.
+     */
+    private final int[] currentProgram = new int[1];
 
     /**
      * Drawable情報のキャッシュ変数

--- a/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismShaderAndroid.java
+++ b/framework/src/main/java/com/live2d/sdk/cubism/framework/rendering/android/CubismShaderAndroid.java
@@ -11,6 +11,7 @@ import com.live2d.sdk.cubism.framework.CubismFramework;
 import com.live2d.sdk.cubism.framework.ICubismLoadFileFunction;
 import com.live2d.sdk.cubism.framework.math.CubismMatrix44;
 import com.live2d.sdk.cubism.framework.model.CubismModel;
+import com.live2d.sdk.cubism.framework.model.CubismModelMultiplyAndScreenColor;
 import com.live2d.sdk.cubism.framework.rendering.CubismRenderer;
 import com.live2d.sdk.cubism.framework.rendering.android.shaderindex.CubismShaderIndexCalculator;
 import com.live2d.sdk.cubism.framework.rendering.android.shaderindex.CubismShaderIndexConstants;
@@ -32,7 +33,7 @@ import static com.live2d.sdk.cubism.framework.utils.CubismDebug.cubismLogError;
 /**
  * This class manage a shader program for Android(OpenGL ES 2.0). This is singleton.
  */
-class CubismShaderAndroid {
+public class CubismShaderAndroid {
     /**
      * Tegra processor support. Enable/Disable drawing by extension method.
      *
@@ -52,6 +53,7 @@ class CubismShaderAndroid {
     public static CubismShaderAndroid getInstance() {
         if (s_instance == null) {
             s_instance = new CubismShaderAndroid();
+            s_instance.generateShaders();
         }
 
         return s_instance;
@@ -61,7 +63,10 @@ class CubismShaderAndroid {
      * Delete this singleton instance.
      */
     public static void deleteInstance() {
-        s_instance = null;
+        if (s_instance != null) {
+            s_instance.releaseShaderProgram();
+            s_instance = null;
+        }
     }
 
     /**
@@ -76,10 +81,6 @@ class CubismShaderAndroid {
         CubismModel model,
         int index
     ) {
-        if (shaderSets.isEmpty()) {
-            generateShaders();
-        }
-
         // Blending
         int srcColor;
         int dstColor;
@@ -145,45 +146,16 @@ class CubismShaderAndroid {
 
         glUseProgram(shaderSet.shaderProgram);
 
-        // キャッシュされたバッファを取得し、実際のデータを格納する。
-        CubismDrawableInfoCachesHolder drawableInfoCachesHolder = renderer.getDrawableInfoCachesHolder();
-        // vertex array
-        FloatBuffer vertexArrayBuffer = drawableInfoCachesHolder.setUpVertexArray(
-            index,
-            model.getDrawableVertices(index)
-        );
-        // uv array
-        FloatBuffer uvArrayBuffer = drawableInfoCachesHolder.setUpUvArray(
-            index,
-            model.getDrawableVertexUvs(index)
-        );
+        // テクスチャ設定
+        setUpTexture(renderer, model, index, shaderSet);
 
-        // setting of vertex array
-        glEnableVertexAttribArray(shaderSet.attributePositionLocation);
-        glVertexAttribPointer(
-            shaderSet.attributePositionLocation,
-            2,
-            GL_FLOAT,
-            false,
-            Float.SIZE / Byte.SIZE * 2,
-            vertexArrayBuffer
-        );
-
-        // setting of texture vertex
-        glEnableVertexAttribArray(shaderSet.attributeTexCoordLocation);
-        glVertexAttribPointer(
-            shaderSet.attributeTexCoordLocation,
-            2,
-            GL_FLOAT,
-            false,
-            Float.SIZE / Byte.SIZE * 2,
-            uvArrayBuffer
-        );
+        // 頂点属性設定
+        setVertexAttributes(renderer, model, index, shaderSet);
 
         if (isMasked) {
             glActiveTexture(GL_TEXTURE1);
 
-            // OffscreenSurfaceに描かれたテクスチャ
+            // RenderTargetに描かれたテクスチャ
             int tex = renderer.getDrawableMaskBuffer(renderer.getClippingContextBufferForDrawable().bufferIndex).getColorBuffer()[0];
             glBindTexture(GL_TEXTURE_2D, tex);
             glUniform1i(shaderSet.samplerTexture1Location, 1);
@@ -211,14 +183,6 @@ class CubismShaderAndroid {
                 colorChannel.a
             );
         }
-
-        // texture setting
-        int textureId = renderer.getBoundTextureId(
-            model.getDrawableTextureIndex(index)
-        );
-        glActiveTexture(GL_TEXTURE0);
-        glBindTexture(GL_TEXTURE_2D, textureId);
-        glUniform1i(shaderSet.samplerTexture0Location, 0);
 
         // ブレンド設定
         if (isBlendMode) {
@@ -261,8 +225,10 @@ class CubismShaderAndroid {
             );
         }
 
-        CubismRenderer.CubismTextureColor multiplyColor = model.getMultiplyColor(index);
-        CubismRenderer.CubismTextureColor screenColor = model.getScreenColor(index);
+        final CubismModelMultiplyAndScreenColor overrideMultiplyAndScreenColor = model.getOverrideMultiplyAndScreenColor();
+        CubismRenderer.CubismTextureColor multiplyColor = overrideMultiplyAndScreenColor.getDrawableMultiplyColor(index);
+        CubismRenderer.CubismTextureColor screenColor = overrideMultiplyAndScreenColor.getDrawableScreenColor(index);
+
         glUniform4f(
             shaderSet.uniformBaseColorLocation,
             baseColor.r,
@@ -300,10 +266,6 @@ class CubismShaderAndroid {
         CubismModel model,
         int index
     ) {
-        if (shaderSets.isEmpty()) {
-            generateShaders();
-        }
-
         // Blending
         int srcColor = GL_ZERO;
         int dstColor = GL_ONE_MINUS_SRC_COLOR;
@@ -314,46 +276,11 @@ class CubismShaderAndroid {
 
         glUseProgram(shaderSet.shaderProgram);
 
-        // texture setting
-        int textureId = renderer.getBoundTextureId(model.getDrawableTextureIndex(index));
-        glActiveTexture(GL_TEXTURE0);
-        glBindTexture(GL_TEXTURE_2D, textureId);
-        glUniform1i(shaderSet.samplerTexture0Location, 0);
+        // テクスチャ設定
+        setUpTexture(renderer, model, index, shaderSet);
 
-        // キャッシュされたバッファを取得し、実際のデータを格納する。
-        CubismDrawableInfoCachesHolder drawableInfoCachesHolder = renderer.getDrawableInfoCachesHolder();
-        // vertex array
-        FloatBuffer vertexArrayBuffer = drawableInfoCachesHolder.setUpVertexArray(
-            index,
-            model.getDrawableVertices(index)
-        );
-        // uv array
-        FloatBuffer uvArrayBuffer = drawableInfoCachesHolder.setUpUvArray(
-            index,
-            model.getDrawableVertexUvs(index)
-        );
-
-        // setting of vertex array
-        glEnableVertexAttribArray(shaderSet.attributePositionLocation);
-        glVertexAttribPointer(
-            shaderSet.attributePositionLocation,
-            2,
-            GL_FLOAT,
-            false,
-            Float.SIZE / Byte.SIZE * 2,
-            vertexArrayBuffer
-        );
-
-        // setting of texture vertex
-        glEnableVertexAttribArray(shaderSet.attributeTexCoordLocation);
-        glVertexAttribPointer(
-            shaderSet.attributeTexCoordLocation,
-            2,
-            GL_FLOAT,
-            false,
-            Float.SIZE / Byte.SIZE * 2,
-            uvArrayBuffer
-        );
+        // 頂点属性設定
+        setVertexAttributes(renderer, model, index, shaderSet);
 
         // 使用するカラーチャンネルを設定
         setColorChannelUniformVariables(
@@ -415,10 +342,6 @@ class CubismShaderAndroid {
         final CubismModel model,
         final CubismOffscreenRenderTargetAndroid offscreen
     ) {
-        if (shaderSets.isEmpty()) {
-            generateShaders();
-        }
-
         // Blending
         int srcColor;
         int dstColor;
@@ -562,8 +485,10 @@ class CubismShaderAndroid {
         baseColor.b = offscreenOpacity;
         baseColor.a = offscreenOpacity;
 
-        CubismRenderer.CubismTextureColor multiplyColor = model.getMultiplyColorOffscreen(offscreenIndex);
-        CubismRenderer.CubismTextureColor screenColor = model.getScreenColorOffscreen(offscreenIndex);
+        final CubismModelMultiplyAndScreenColor overrideMultiplyAndScreenColor = model.getOverrideMultiplyAndScreenColor();
+        CubismRenderer.CubismTextureColor multiplyColor = overrideMultiplyAndScreenColor.getOffscreenMultiplyColor(offscreenIndex);
+        CubismRenderer.CubismTextureColor screenColor = overrideMultiplyAndScreenColor.getOffscreenScreenColor(offscreenIndex);
+
         setColorUniformVariables(renderer, model, offscreenIndex, shaderSet, baseColor, multiplyColor, screenColor);
 
         glBlendFuncSeparate(srcColor, dstColor, srcAlpha, dstAlpha);
@@ -610,10 +535,6 @@ class CubismShaderAndroid {
         int dstAlpha,
         CubismRenderer.CubismTextureColor baseColor
     ) {
-        if (shaderSets.isEmpty()) {
-            generateShaders();
-        }
-
         CubismShaderSet shaderSet = shaderSets.get(CubismShaderIndexFactors.UtilityShaderType.COPY.index);
         glUseProgram(shaderSet.shaderProgram);
 
@@ -897,10 +818,18 @@ class CubismShaderAndroid {
      * Release shader programs.
      */
     private void releaseShaderProgram() {
-        for (CubismShaderSet shaderSet : shaderSets) {
-            glDeleteProgram(shaderSet.shaderProgram);
-            shaderSet.shaderProgram = 0;
+        for (int i = 0; i < shaderSets.size(); i++) {
+            if (shaderSets.get(i).shaderProgram != 0) {
+                glDeleteProgram(shaderSets.get(i).shaderProgram);
+                shaderSets.get(i).shaderProgram = 0;
+            }
         }
+    }
+
+    /**
+     * Release invalidated shader program information. Call this when the GL context has been destroyed.
+     */
+    public void releaseInvalidShaderProgram() {
         shaderSets.clear();
     }
 
@@ -908,6 +837,10 @@ class CubismShaderAndroid {
      * Initialize and generate shader programs.
      */
     private void generateShaders() {
+        if (!shaderSets.isEmpty()) {
+            return;
+        }
+
         for (int i = 0; i < CubismShaderIndexConstants.SHADER_COUNT; i++) {
             shaderSets.add(new CubismShaderSet());
         }
@@ -1316,6 +1249,68 @@ class CubismShaderAndroid {
         int[] status = new int[1];
         glGetProgramiv(shaderProgram, GL_VALIDATE_STATUS, IntBuffer.wrap(status));
         return status[0] != GL_FALSE;
+    }
+
+    /**
+     * Set up vertex attributes for drawing.
+     *
+     * @param renderer  renderer instance
+     * @param model     rendered model
+     * @param index     target drawable index
+     * @param shaderSet shader program set
+     */
+    private void setVertexAttributes(CubismRendererAndroid renderer, CubismModel model, int index, CubismShaderSet shaderSet) {
+        CubismDrawableInfoCachesHolder drawableInfoCachesHolder = renderer.getDrawableInfoCachesHolder();
+
+        // 頂点位置属性の設定
+        FloatBuffer vertexArrayBuffer = drawableInfoCachesHolder.setUpVertexArray(
+            index,
+            model.getDrawableVertices(index)
+        );
+        glEnableVertexAttribArray(shaderSet.attributePositionLocation);
+        glVertexAttribPointer(
+            shaderSet.attributePositionLocation,
+            2,
+            GL_FLOAT,
+            false,
+            Float.SIZE / Byte.SIZE * 2,
+            vertexArrayBuffer
+        );
+
+        // テクスチャ座標属性の設定
+        FloatBuffer uvArrayBuffer = drawableInfoCachesHolder.setUpUvArray(
+            index,
+            model.getDrawableVertexUvs(index)
+        );
+        glEnableVertexAttribArray(shaderSet.attributeTexCoordLocation);
+        glVertexAttribPointer(
+            shaderSet.attributeTexCoordLocation,
+            2,
+            GL_FLOAT,
+            false,
+            Float.SIZE / Byte.SIZE * 2,
+            uvArrayBuffer
+        );
+    }
+
+    /**
+     * Set up the texture for drawing.
+     *
+     * @param renderer  renderer instance
+     * @param model     rendered model
+     * @param index     target drawable index
+     * @param shaderSet shader program set
+     */
+    private void setUpTexture(CubismRendererAndroid renderer, CubismModel model, int index, CubismShaderSet shaderSet) {
+        int textureIndex = model.getDrawableTextureIndex(index);
+        int textureId = renderer.getBoundTextureId(textureIndex);
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, textureId);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glUniform1i(shaderSet.samplerTexture0Location, 0);
     }
 
     /**


### PR DESCRIPTION
### Added

* Add a validation check for the current shader program before drawing polygon meshes.
* Add `deleteRenderer()` method to `CubismUserModel` class.
* Add `releaseInvalidShaderProgram()` method to `CubismShaderAndroid` class for releasing resources that have already been destroyed by the environment.
* Add `CubismUpdateScheduler` class to control the order in which model parameter updates are executed.
* Add `CubismLook` class for drag-driven parameter following with configurable parameter IDs.
* Add `ACubismUpdater` abstract class and per-feature Updater subclasses (`CubismBreathUpdater`, `CubismExpressionUpdater`, `CubismEyeBlinkUpdater`, `CubismLipSyncUpdater`, `CubismLookUpdater`, `CubismPhysicsUpdater`, `CubismPoseUpdater`) used by `CubismUpdateScheduler` class.
* Add `IParameterProvider` interface used to supply parameter values such as lip sync.
* Add `IBooleanSupplier` functional interface used to read the latest value of a boolean field on every call.

### Changed

* Consolidate texture setup and vertex attribute setup code into dedicated methods in `CubismShaderAndroid` class.
* Change shader generation from draw loop to `initialize()` in `CubismRendererAndroid` class.
* Change the visibility of `CubismShaderAndroid` class from package-private to public.
* Separate multiply color and screen color functions into a new class with renamed methods.
* Change sampler settings in `CubismRenderTargetAndroid` and `CubismShaderAndroid` classes to align with the OpenGL ES 2.0 setting of SDK for Native.

### Fixed

* Unify remaining uses of `OffscreenSurface` in comments and parameter names to `RenderTarget`.
* Fix an issue where `close()` method in `CubismRenderer` class unintentionally released model resources.
* Fix `setupRenderer()` method in `CubismUserModel` class to delete the existing renderer before setting up a new one.
* Fix `CubismShaderAndroid.deleteInstance()` to properly release shader programs by calling `glDeleteProgram()`.
* Fix missing `@FunctionalInterface` annotation on functional interfaces.

### Removed

* Remove `lipSync`, `dragX`, and `dragY` fields from `CubismUserModel` class. Drag-driven parameter updates have been moved into the new `CubismLook` class, invoked by `CubismLookUpdater` class. Lip sync is handled by `CubismLipSyncUpdater` class together with `IParameterProvider` interface.